### PR TITLE
chore: remove `github.ref` in ci.yml 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Set up Deno
         uses: denoland/setup-deno@v1.0.0


### PR DESCRIPTION
This is implicitly the default.