### PR TITLE
docs(sanitizers): fix link to architecture doc

### DIFF
--- a/testing/sanitizers.md
+++ b/testing/sanitizers.md
@@ -6,7 +6,7 @@ reasonable and expected way.
 ### Resource sanitizer
 
 Certain actions in Deno create resources in the resource table
-([learn more here](./contributing/architecture.md)).
+([learn more here](../contributing/architecture.md)).
 
 These resources should be closed after you are done using them.
 


### PR DESCRIPTION
Without `../`, the link goes to the 404 page.
https://deno.land/manual@v1.12.2/testing/sanitizers#resource-sanitizer