### PR TITLE
HTTP: Fix the handle function example

### DIFF
--- a/runtime/http_server_apis.md
+++ b/runtime/http_server_apis.md
@@ -191,7 +191,7 @@ async function handle(conn: Deno.Conn) {
   const httpConn = Deno.serveHttp(conn);
   for await (const requestEvent of httpConn) {
     const url = new URL(requestEvent.request.url);
-    console.log(`path: ${url.path}`);
+    console.log(`path: ${url.pathname}`);
   }
 }
 ```


### PR DESCRIPTION
When trying out the new (amazing) HTTP interface of Deno, I found a mistake in the documentation:
The example of the handle function does not work, as URL provides the path via the `pathname` attribute, not `path`.

[MDN docs on the topic](https://developer.mozilla.org/en-US/docs/Web/API/URL)

Thanks for your amazing work on the manual 🙇 