### PR TITLE
fix doc "deno doc std node assert" command typo

### DIFF
--- a/npm_nodejs/std_node.md
+++ b/npm_nodejs/std_node.md
@@ -52,7 +52,7 @@ If you want documentation for any of the modules, you can simply type `deno doc`
 and the URL of the module in your terminal:
 
 ```
-> deno doc https://deno.land/std/node/assert.ts
+> deno doc https://deno.land/std/fs/move.ts
 ```
 
 ### Loading CommonJS modules

--- a/npm_nodejs/std_node.md
+++ b/npm_nodejs/std_node.md
@@ -52,7 +52,7 @@ If you want documentation for any of the modules, you can simply type `deno doc`
 and the URL of the module in your terminal:
 
 ```
-> deno doc https://deno.land/std/assert.ts
+> deno doc https://deno.land/std/node/assert.ts
 ```
 
 ### Loading CommonJS modules


### PR DESCRIPTION
```
deno doc https://deno.land/std/assert.ts
Download https://deno.land/std/assert.ts
Warning Implicitly using latest version (0.105.0) for https://deno.land/std/assert.ts
Download https://deno.land/std@0.105.0/assert.ts
The graph is missing a dependency.
  Specifier: https://deno.land/std/assert.ts from file:///Users/.../$deno$doc.ts
```
➜  deno doc https://deno.land/std/assert.ts     
-> 
➜  deno doc https://deno.land/std/node/assert.ts