### PR TITLE
Update Deno.run when running commands with bash shell.

### DIFF
--- a/examples/subprocess.md
+++ b/examples/subprocess.md
@@ -11,7 +11,7 @@
   [stdout](https://doc.deno.land/builtin/stable#Deno.stdout) and
   [stderr](https://doc.deno.land/builtin/stable#Deno.stderr) streams.
 - Use a specific shell by providing its path/name and its string input switch,
-  e.g. `Deno.run({cmd: ["bash", "-c", '"ls -la"']});`
+  e.g. `Deno.run({cmd: ["bash", "-c", "ls -la"]});`
 
 ## Simple example
 


### PR DESCRIPTION
When using double quotes inside single quotes raises this error:

![image](https://user-images.githubusercontent.com/7959437/130533449-6d968d66-60b0-4a21-b873-69c89b23b3d5.png)

Leaving only one of them solves the issue:

![image](https://user-images.githubusercontent.com/7959437/130533507-e70553a7-e065-4762-b225-d8b426419fd2.png)
