### PR TITLE
docs(examples): update `http_server` example to use new native server APIs

### DIFF
--- a/examples/http_server.md
+++ b/examples/http_server.md
@@ -59,23 +59,22 @@ Then navigate to `http://localhost:8080/` in a browser.
 
 ### Using the `std/http` library
 
-> ℹ️ Since stabilization of _native_ HTTP server in 1.13, usage of `std/http` is
-> discouraged. The module is planned to be deprecated in the future releases.
-
 **webserver.ts**:
 
 ```ts
-import { serve } from "https://deno.land/std@$STD_VERSION/http/server.ts";
+import { listenAndServe } from "https://deno.land/std@$STD_VERSION/http/server.ts";
 
-const server = serve({ port: 8080 });
-console.log(`HTTP webserver running.  Access it at:  http://localhost:8080/`);
+const addr = ":8080";
 
-for await (const request of server) {
-  let bodyContent = "Your user-agent is:\n\n";
-  bodyContent += request.headers.get("user-agent") || "Unknown";
+const handler = (request: Request): Response => {
+  let body = "Your user-agent is:\n\n";
+  body += request.headers.get("user-agent") || "Unknown";
 
-  request.respond({ status: 200, body: bodyContent });
+  return new Response(body, { status: 200 });
 }
+
+console.log(`HTTP webserver running. Access it at: http://localhost:8080/`);
+await listenAndServe(addr, handler));
 ```
 
 Then run this with:

--- a/examples/http_server.md
+++ b/examples/http_server.md
@@ -61,8 +61,8 @@ Then navigate to `http://localhost:8080/` in a browser.
 
 > ℹ️ Since the stabilization of _native_ HTTP bindings in `^1.13.x`, `std/http`
 > now supports both a _native_ HTTP server and legacy JavaScript HTTP server
-> from `^0.107.0`. The legacy server module is now deprecated, and is planned
-> to be removed in a future release.
+> from `^0.107.0`. The legacy server module is now deprecated, and is planned to
+> be removed in a future release.
 
 **webserver.ts**:
 

--- a/examples/http_server.md
+++ b/examples/http_server.md
@@ -71,10 +71,10 @@ const handler = (request: Request): Response => {
   body += request.headers.get("user-agent") || "Unknown";
 
   return new Response(body, { status: 200 });
-}
+};
 
 console.log(`HTTP webserver running. Access it at: http://localhost:8080/`);
-await listenAndServe(addr, handler));
+await listenAndServe(addr, handler);
 ```
 
 Then run this with:

--- a/examples/http_server.md
+++ b/examples/http_server.md
@@ -59,6 +59,11 @@ Then navigate to `http://localhost:8080/` in a browser.
 
 ### Using the `std/http` library
 
+> ℹ️ Since the stabilization of _native_ HTTP bindings in 1.13, `std/http` now
+> supports both a _native_ HTTP server and legacy JavaScript HTTP server. The
+> legacy server module is now deprecated, and is planned to be removed in a
+> future release.
+
 **webserver.ts**:
 
 ```ts
@@ -81,4 +86,25 @@ Then run this with:
 
 ```shell
 deno run --allow-net webserver.ts
+```
+
+**webserver_legacy.ts**
+
+```ts
+import { serve } from "https://deno.land/std@$STD_VERSION/http/server_legacy.ts";
+
+const server = serve({ port: 8080 });
+console.log(`HTTP webserver running. Access it at: http://localhost:8080/`);
+
+for await (const request of server) {
+  let body = "Your user-agent is:\n\n";
+  body += request.headers.get("user-agent") || "Unknown";
+  request.respond({ status: 200, body });
+}
+```
+
+Then run this with:
+
+```shell
+deno run --allow-net webserver_legacy.ts
 ```

--- a/examples/http_server.md
+++ b/examples/http_server.md
@@ -59,10 +59,10 @@ Then navigate to `http://localhost:8080/` in a browser.
 
 ### Using the `std/http` library
 
-> ℹ️ Since the stabilization of _native_ HTTP bindings in 1.13, `std/http` now
-> supports both a _native_ HTTP server and legacy JavaScript HTTP server. The
-> legacy server module is now deprecated, and is planned to be removed in a
-> future release.
+> ℹ️ Since the stabilization of _native_ HTTP bindings in `^1.13.x`, `std/http`
+> now supports both a _native_ HTTP server and legacy JavaScript HTTP server
+> from `^0.107.0`. The legacy server module is now deprecated, and is planned
+> to be removed in a future release.
 
 **webserver.ts**:
 


### PR DESCRIPTION
Relates to https://github.com/denoland/deno_std/discussions/1034 and https://github.com/denoland/deno_std/pull/1128.

Updates the `http_server` example to use the new std/http "native" server APIs.