### PR TITLE
fix(docs): add mailto markdown syntax to email link

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -91,7 +91,7 @@ Official Docker images for Deno.
 
 - Please be professional in the forums. We follow
   [Rust's code of conduct](https://www.rust-lang.org/policies/code-of-conduct)
-  (CoC). Have a problem? Email ry@tinyclouds.org.
+  (CoC). Have a problem? Email [ry@tinyclouds.org](mailto:ry@tinyclouds.org).
 
 ## Submitting a pull request
 


### PR DESCRIPTION
This should fix #72