### PR TITLE
docs: deno fmt list of files & how they are matched

### DIFF
--- a/tools/formatter.md
+++ b/tools/formatter.md
@@ -1,6 +1,7 @@
 ## Code formatter
 
-Deno ships with a built in code formatter that will auto-format the following files:
+Deno ships with a built in code formatter that will auto-format the following
+files:
 
 | File Type  | Extension          |
 | ---------- | ------------------ |

--- a/tools/formatter.md
+++ b/tools/formatter.md
@@ -1,7 +1,16 @@
 ## Code formatter
 
-Deno ships with a built in code formatter that auto-formats TypeScript,
-JavaScript, Markdown, JSON, and JSONC code.
+Deno ships with a built in code formatter that will auto-format the following files:
+
+| File Type  | Extension          |
+| ---------- | ------------------ |
+| JavaScript | `.js`              |
+| TypeScript | `.ts`              |
+| Markdown   | `.md`, `.markdown` |
+| JSON       | `.json`            |
+| JSONC      | `.jsonc`           |
+
+as well as code snippets within Markdown files.
 
 ```shell
 # format all supported files in the current directory and subdirectories

--- a/tools/formatter.md
+++ b/tools/formatter.md
@@ -6,6 +6,8 @@ Deno ships with a built in code formatter that will auto-format the following fi
 | ---------- | ------------------ |
 | JavaScript | `.js`              |
 | TypeScript | `.ts`              |
+| JSX        | `.jsx`             |
+| TSX        | `.tsx`             |
 | Markdown   | `.md`, `.markdown` |
 | JSON       | `.json`            |
 | JSONC      | `.jsonc`           |


### PR DESCRIPTION
This would describe to users at a glance what file types are supported and how the formatter matches those file types.

I do not know if this list is correct, but I came to this page expecting this information to be shared.