### PR TITLE
docs: fix a typo in the setup environment doc

### DIFF
--- a/getting_started/setup_your_environment.md
+++ b/getting_started/setup_your_environment.md
@@ -31,7 +31,7 @@ When installed, it will connect to the language server built into the Deno CLI.
 
 Because most people work in mixed environments, the extension does not enable a
 workspace as _Deno enabled_ by default, and it requires that the
-`"deno.enabled"` flag to be set. You can change the settings yourself, or you
+`"deno.enable"` flag to be set. You can change the settings yourself, or you
 can choose `Deno: Initialize Workspace Configuration` from the command palette
 to enable your project.
 

--- a/getting_started/setup_your_environment.md
+++ b/getting_started/setup_your_environment.md
@@ -30,10 +30,10 @@ There is an official extension for
 When installed, it will connect to the language server built into the Deno CLI.
 
 Because most people work in mixed environments, the extension does not enable a
-workspace as _Deno enabled_ by default, and it requires that the
-`"deno.enable"` flag to be set. You can change the settings yourself, or you
-can choose `Deno: Initialize Workspace Configuration` from the command palette
-to enable your project.
+workspace as _Deno enabled_ by default, and it requires that the `"deno.enable"`
+flag to be set. You can change the settings yourself, or you can choose
+`Deno: Initialize Workspace Configuration` from the command palette to enable
+your project.
 
 More information can be found in the
 [Using Visual Studio Code](../vscode_deno.md) section of the manual.


### PR DESCRIPTION
Very small change to fix a typo in the docs. 
The correct setting to enable deno in Visual studio code is `deno.enable`, not `deno.enabled`

I spent several minutes trying to understand what was wrong with my vs code, but then I realised that it was just a typo in the docs. I hope this can help someone else!