### PR TITLE
docs(lint): fix link to configuration_file.md

### DIFF
--- a/tools/linter.md
+++ b/tools/linter.md
@@ -152,7 +152,8 @@ function bar(a: any) {
 ### Configuration
 
 Starting with Deno v1.14 a linter can be customized using either
-[a configuration file](../getting_started/configuration_file.md) or following CLI flags:
+[a configuration file](../getting_started/configuration_file.md) or following
+CLI flags:
 
 - `--rules-tags` - List of tag names that will be run. Empty list disables all
   tags and will only use rules from `include`. Defaults to "recommended".

--- a/tools/linter.md
+++ b/tools/linter.md
@@ -152,7 +152,7 @@ function bar(a: any) {
 ### Configuration
 
 Starting with Deno v1.14 a linter can be customized using either
-[a configuration file](../configuration_file.md) or following CLI flags:
+[a configuration file](../getting_started/configuration_file.md) or following CLI flags:
 
 - `--rules-tags` - List of tag names that will be run. Empty list disables all
   tags and will only use rules from `include`. Defaults to "recommended".


### PR DESCRIPTION
The current link brings us to https://deno.land/manual@v1.14.1/configuration_file, which is 404 not found. The correct target should be https://deno.land/manual@v1.14.1/getting_started/configuration_file.