### PR TITLE
Update permissions.md

### DIFF
--- a/getting_started/permissions.md
+++ b/getting_started/permissions.md
@@ -51,8 +51,8 @@ Some permissions allow you to grant access to a specific list of entities
 
 #### File system access
 
-This example restricts file system access by allowing read-only access to
-the `/usr` directory. In consequence the execution fails as the process was
+This example restricts file system access by allowing read-only access to the
+`/usr` directory. In consequence the execution fails as the process was
 attempting to read a file in the `/etc` directory:
 
 ```shell
@@ -63,7 +63,8 @@ error: Uncaught PermissionDenied: read access to "/etc/passwd", run again with t
     ...
 ```
 
-Try it out again with the correct permissions by allowing access to `/etc` instead:
+Try it out again with the correct permissions by allowing access to `/etc`
+instead:
 
 ```shell
 deno run --allow-read=/etc https://deno.land/std@$STD_VERSION/examples/cat.ts /etc/passwd
@@ -83,8 +84,8 @@ deno run --allow-read=/etc https://deno.land/std@$STD_VERSION/examples/cat.ts /e
 const result = await fetch("https://deno.land/");
 ```
 
-This is an example of how to allow network access to specific hostnames or ip addresses, optionally
-locked to a specified port:
+This is an example of how to allow network access to specific hostnames or ip
+addresses, optionally locked to a specified port:
 
 ```shell
 # Multiple hostnames, all ports allowed
@@ -157,8 +158,8 @@ deno run --allow-run=whoami run.js
 deno run --allow-run run.js
 ```
 
-You can only limit the executables that are allowed; if permission is granted
-to execute it then any parameters can be passed. For example if you pass
+You can only limit the executables that are allowed; if permission is granted to
+execute it then any parameters can be passed. For example if you pass
 `--allow-run=cat` then the user can use `cat` to read any file.
 
 ### Conference

--- a/getting_started/permissions.md
+++ b/getting_started/permissions.md
@@ -2,7 +2,7 @@
 
 Deno is secure by default. Therefore, unless you specifically enable it, a
 program run with Deno has no file, network, or environment access. Access to
-security sensitive functionality requires that permisisons have been granted to
+security sensitive functionality requires that permissions have been granted to
 an executing script through command line flags, or a runtime permission prompt.
 
 For the following example `mod.ts` has been granted read-only access to the file
@@ -44,13 +44,14 @@ The following permissions are available:
 - **-A, --allow-all** Allow all permissions. This enables all security sensitive
   functions. Use with caution.
 
-### Permissions allow-list
+### Configurable permissions
 
-Deno allows you to control the granularity of some permissions with allow-lists.
+Some permissions allow you to grant access to a specific list of entities
+(files, servers, etc) rather than to everything.
 
 #### File system access
 
-This example restricts file system access by allow-listing only read access to
+This example restricts file system access by allowing read-only access to
 the `/usr` directory. In consequence the execution fails as the process was
 attempting to read a file in the `/etc` directory:
 
@@ -62,7 +63,7 @@ error: Uncaught PermissionDenied: read access to "/etc/passwd", run again with t
     ...
 ```
 
-Try it out again with the correct permissions by allow-listing `/etc` instead:
+Try it out again with the correct permissions by allowing access to `/etc` instead:
 
 ```shell
 deno run --allow-read=/etc https://deno.land/std@$STD_VERSION/examples/cat.ts /etc/passwd
@@ -82,7 +83,7 @@ deno run --allow-read=/etc https://deno.land/std@$STD_VERSION/examples/cat.ts /e
 const result = await fetch("https://deno.land/");
 ```
 
-This is an example of how to allow-list hostnames, ip addresses, optionally
+This is an example of how to allow network access to specific hostnames or ip addresses, optionally
 locked to a specified port:
 
 ```shell
@@ -100,7 +101,7 @@ deno run --allow-net=[2606:4700:4700::1111] fetch.js
 ```
 
 If `fetch.js` tries to establish network connections to any hostname or IP not
-in the allow-list, the relevant call will error.
+explicitly allowed, the relevant call will throw an exception.
 
 Allow net calls to any hostname/ip:
 
@@ -115,7 +116,7 @@ deno run --allow-net fetch.js
 Deno.env.get("HOME");
 ```
 
-This is an example of how to allow-list environment variables:
+This is an example of how to allow access to environment variables:
 
 ```shell
 # Allow all environment variables
@@ -126,7 +127,7 @@ deno run --allow-env=HOME env.js
 ```
 
 > Note for Windows users: environment variables are case insensitive on Windows,
-> so Deno also matches them case insensitively in the allow-list.
+> so Deno also matches them case insensitively (on Windows only).
 
 #### Subprocess permissions
 
@@ -140,25 +141,25 @@ directly. This is often reffered to as privledge escalation.
 Because of this, make sure you carefully consider if you want to grant a program
 `--allow-run` access: it essentially invalidates the Deno security sandbox. If
 you really need to spawn a specific executable, you can reduce the risk by
-limiting which programs a Deno process can start using an allow-list for the
-`--allow-run` flag:
+limiting which programs a Deno process can start by passing specific executable
+names to the `--allow-run` flag.
 
 ```js
 // run.js
-const proc = Deno.run({ cmd: ["cat", "/etc/passwd"] });
+const proc = Deno.run({ cmd: ["whoami"] });
 ```
 
 ```shell
-# Allow only spawning a `cat` subprocess:
-deno run --allow-run=cat run.js
+# Allow only spawning a `whoami` subprocess:
+deno run --allow-run=whoami run.js
 
 # Allow running any subprocess:
 deno run --allow-run run.js
 ```
 
-> Note for Windows users: the `cat` executable and the `/etc/passwd` file do not
-> exist on Windows. To try out this example you will need to replace these with
-> an alternatives that exist on Windows.
+You can only limit the executables that are allowed; if permission is granted
+to execute it then any parameters can be passed. For example if you pass
+`--allow-run=cat` then the user can use `cat` to read any file.
 
 ### Conference
 


### PR DESCRIPTION
* Fix typo
* A couple of clarifications
* Change `cat` to `whoami` which is available on Windows, Mac and Linux. On the downside I had to remove the argument so I added an explicit note about that.
* Remove problematic `allow-list`. It would be better with "whitelist" but was able to make it flow much better anyway using other normal words.