### PR TITLE
fix(docs): update two typos

### DIFF
--- a/tools/dependency_inspector.md
+++ b/tools/dependency_inspector.md
@@ -8,8 +8,8 @@ Download https://deno.land/std@0.67.0/http/file_server.ts
 ...
 local: /home/deno/.cache/deno/deps/https/deno.land/f57792e36f2dbf28b14a75e2372a479c6392780d4712d76698d5031f943c0020
 type: TypeScript
-compiled: /home/deno/.cache/deno/gen/https/deno.land/f57792e36f2dbf28b14a75e2372a479c6392780d4712d76698d5031f943c0020.js
-deps: 23 unique (total 139.89KB)
+emit: /home/deno/.cache/deno/gen/https/deno.land/f57792e36f2dbf28b14a75e2372a479c6392780d4712d76698d5031f943c0020.js
+dependencies: 23 unique (total 139.89KB)
 https://deno.land/std@0.67.0/http/file_server.ts (10.49KB)
 ├─┬ https://deno.land/std@0.67.0/path/mod.ts (717B)
 │ ├── https://deno.land/std@0.67.0/path/_constants.ts (2.35KB)

--- a/typescript/configuration.md
+++ b/typescript/configuration.md
@@ -25,7 +25,7 @@ a path on the command line. For example:
 > longer confined to specifying TypeScript compiler settings. Using
 > `tsconfig.json` as a file name will still work, but we recommend to use
 > `deno.json` or `deno.jsonc`, as an automatic lookup of this file is planned
-> for an upcoming releases.
+> for an upcoming release.
 
 ### How Deno uses a configuration file
 
@@ -207,6 +207,6 @@ could be trivial errors becoming runtime errors.
 ### Using the "types" property
 
 The `"types"` property in `"compilerOptions"` can be used to specify arbitrary
-type definitions to include when type checking a programme. For more information
+type definitions to include when type checking a program. For more information
 on this see
 [Using ambient or global types](./types#using-ambient-or-global-types).


### PR DESCRIPTION
This fixes not one, but two whole typos in the manual.



:)