### PR TITLE
Update TOC to match page heading

### DIFF
--- a/toc.json
+++ b/toc.json
@@ -6,7 +6,7 @@
     "name": "Getting Started",
     "children": {
       "installation": "Installation",
-      "setup_your_environment": "Setup your environment",
+      "setup_your_environment": "Set up your environment",
       "first_steps": "First steps",
       "command_line_interface": "Command line interface",
       "configuration_file": "Configuration file",


### PR DESCRIPTION
mostly a grammatical nit: "Setup your environment" -> "Set up your environment" to match [this page heading](https://github.com/denoland/manual/blob/5391d1435c150e051b585b61dcf0823503587a4e/getting_started/setup_your_environment.md?plain=1#L1)