### PR TITLE
testing: add example for Chai and Sinon

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -167,3 +167,13 @@ failure, you can specify the `--fail-fast` flag when running the suite.
 ```shell
 deno test --fail-fast
 ```
+
+## Integration with testing libraries
+
+Deno's test runner works with popular testing libraries like
+[Chai](https://www.chaijs.com/) or [Sinon.JS](https://sinonjs.org/).
+
+For example integration see:
+
+- https://deno.land/std@$STD_VERSION/testing/chai_example.ts
+- https://deno.land/std@$STD_VERSION/testing/sinon_example.ts

--- a/testing/assertions.md
+++ b/testing/assertions.md
@@ -4,6 +4,10 @@ To help developers write tests the Deno standard library comes with a built in
 [assertions module](https://deno.land/std@$STD_VERSION/testing/asserts.ts) which
 can be imported from `https://deno.land/std@$STD_VERSION/testing/asserts.ts`.
 
+Some popular assertion libraries, like [Chai](https://www.chaijs.com/), can be
+used in Deno too, for example usage see
+https://deno.land/std@$STD_VERSION/testing/chai_example.ts.
+
 ```js
 import { assert } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
 

--- a/testing/assertions.md
+++ b/testing/assertions.md
@@ -4,10 +4,6 @@ To help developers write tests the Deno standard library comes with a built in
 [assertions module](https://deno.land/std@$STD_VERSION/testing/asserts.ts) which
 can be imported from `https://deno.land/std@$STD_VERSION/testing/asserts.ts`.
 
-Some popular assertion libraries, like [Chai](https://www.chaijs.com/), can be
-used in Deno too, for example usage see
-https://deno.land/std@$STD_VERSION/testing/chai_example.ts.
-
 ```js
 import { assert } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
 
@@ -15,6 +11,10 @@ Deno.test("Hello Test", () => {
   assert("Hello");
 });
 ```
+
+> ⚠️ Some popular assertion libraries, like [Chai](https://www.chaijs.com/), can
+> be used in Deno too, for example usage see
+> https://deno.land/std@$STD_VERSION/testing/chai_example.ts.
 
 The assertions module provides 10 assertions:
 


### PR DESCRIPTION
Closes #107 

Should be merged after `deno_std` 0.111.0 is released, because links don't work right now.