### PR TITLE
fix: Typos in npm_nodejs cdns.md and std_node.md

### DIFF
--- a/npm_nodejs/cdns.md
+++ b/npm_nodejs/cdns.md
@@ -26,7 +26,7 @@ Deno friendly content delivery networks (CDNs) not only host packages from npm,
 they provide them in a way that maximizes their integration to Deno. They
 directly address some of the challenges in consuming code written for Node.js:
 
-- The provide packages and modules in the ES Module format, irrespective of how
+- They provide packages and modules in the ES Module format, irrespective of how
   they are published on npm.
 - They resolve all the dependencies as the modules are served, meaning that all
   the Node.js specific module resolution logic is handled by the CDN.

--- a/npm_nodejs/std_node.md
+++ b/npm_nodejs/std_node.md
@@ -1,7 +1,7 @@
 ## The `std/node` library
 
 The `std/node` part of the Deno standard library is a Node.js compatibility
-layer. It's primary focus is providing "polyfills" for Node.js's
+layer. Its primary focus is providing "polyfills" for Node.js's
 [built-in modules](https://github.com/denoland/deno_std/tree/main/node#supported-builtins).
 It also provides a mechanism for loading CommonJS modules into Deno.
 


### PR DESCRIPTION
This PR fixes two small typos I found while reading the "Using npm/Node.js code" section of the manual:
- "The" should be "They" (describing 'Deno "friendly" CDNs')
- "It's primary focus" should be "Its primary focus" since ["It's" means "It is" or "It has", and "Its" is possessive](https://www.grammarly.com/blog/its-vs-its/). 
