### PR TITLE
chore: remove sentence about running `deno fmt --check` without `--check` on a CI

### DIFF
--- a/continuous_integration.md
+++ b/continuous_integration.md
@@ -71,9 +71,7 @@ Let's go over the steps one by one.
 ```
 
 This simply checks if the project code is formatted according to Deno's default
-formatting conventions. Alternatively, you can also run `deno fmt` without
-`--check` to let the pipeline handle the formatting altogether, if you prefer
-the increased automation.
+formatting conventions.
 
 ```yaml
 - name: Analyze code


### PR DESCRIPTION
I'm not sure running `deno fmt` without `--check` is useful on a CI unless the user has the pipeline commit the formatted code afterwards. Because this is not described (and I don't think it's worth describing), I think we should just remove this sentence.

cc @GJZwiers