### PR TITLE
the websocket 'upgrade' header value is now compared case-insensitively

### DIFF
--- a/runtime/http_server_apis.md
+++ b/runtime/http_server_apis.md
@@ -290,7 +290,8 @@ async function handle(conn: Deno.Conn) {
 }
 
 function handleReq(req: Request): Response {
-  if (req.headers.get("upgrade") != "websocket") {
+  const upgrade = req.headers.get("upgrade") || "";
+  if (upgrade.toLowerCase() != "websocket") {
     return new Response("request isn't trying to upgrade to websocket.");
   }
   const { socket, response } = Deno.upgradeWebSocket(req);


### PR DESCRIPTION
The Manual section for a [WebSocket server](https://deno.land/manual@v1.14.3/runtime/http_server_apis#serving-websockets) is checking the `Upgrade` header value for an exact `"websocket"` match. In practice, this header turns out to often (always?) be `"WebSocket"`. This PR makes the comparison case-insensitive.

Alternatively, if the WebSocket spec mandates the CamelCase version (and header values are case sensitive), I could adjust the exact string comparison for the proper value. My RFC knowledge is not high enough here.