### PR TITLE
Improve and expand Neovim documentation

### DIFF
--- a/getting_started/setup_your_environment.md
+++ b/getting_started/setup_your_environment.md
@@ -77,8 +77,10 @@ To use the Deno language server install
 instructions to enable the
 [supplied Deno configuration](https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md#denols).
 
-Deno's linting is not supported out of the box, but the default of
-`lint = false` can be overridden as follows:
+Deno's linting is not supported out of the box, but assuming you are using the
+`on_attach` helper function from the
+[basic setup example](https://github.com/neovim/nvim-lspconfig#keybindings-and-completion),
+the default of `lint = false` can be overridden as follows:
 
 ```lua
 nvim_lsp.denols.setup {


### PR DESCRIPTION
An alternative to https://github.com/denoland/manual/pull/57#issuecomment-935538472 as requested by @bartlomieju 

This update contains important information about Neovim 0.6 nightly and explains how to enable linting. It hopefully makes everything easier to understand by introducing a separate heading.

Also, the phrase `Outside of` is a redundancy I could not help but correct :)

PS I am not sure how to squash those commits into one, I assume you can do that?