### PR TITLE
Fixed typo in Deno fmt and added example block

### DIFF
--- a/tools/formatter.md
+++ b/tools/formatter.md
@@ -29,13 +29,6 @@ deno fmt --check
 cat file.ts | deno fmt -
 ```
 
-> ⚠️ If you want to redirect output of `deno fmt`, keep in mind that formatted
-> code is output to standard output.
-
-```shell
-cat file.ts | deno fmt - > formatted_file.ts
-```
-
 ### Ignoring Code
 
 Ignore formatting code by preceding it with a `// deno-fmt-ignore` comment in


### PR DESCRIPTION
`deno fmt -` redirects to standard output instead of standard error:

![image](https://user-images.githubusercontent.com/7959437/137675249-febef5e4-d7ec-4bd8-bef1-7c450c7ab48d.png)

Also added an example block to see it working.