### PR TITLE
Update JetBrains section in "Set up your environment"

### DIFF
--- a/getting_started/setup_your_environment.md
+++ b/getting_started/setup_your_environment.md
@@ -38,23 +38,10 @@ your project.
 More information can be found in the
 [Using Visual Studio Code](../vscode_deno.md) section of the manual.
 
-#### JetBrains' IntelliJ IDEA and WebStorm
+#### JetBrains IDEs
 
 Currently support for [JetBrains](https://www.jetbrains.com/) IDEs is available
 through [the Deno plugin](https://plugins.jetbrains.com/plugin/14382-deno).
-
-Once installed, replace the content of
-`External Libraries > Deno Library > lib > lib.deno.d.ts` with the output of
-`deno types`. This will ensure the typings for the extension match the current
-version. You will have to do this every time you update the version of Deno. For
-more information on how to set-up your JetBrains IDE for Deno, read
-[this comment](https://youtrack.jetbrains.com/issue/WEB-41607#focus=streamItem-27-4160152.0-0)
-on YouTrack.
-
-JetBrain's is considering migrating to the Deno language server (see:
-[YouTrack WEB-48625](https://youtrack.jetbrains.com/issue/WEB-48625)). If you
-are a user of JetBrains and Deno, voicing your support can continue help
-JetBrains prioritize support.
 
 #### vim/Neovim
 


### PR DESCRIPTION
Starting with WebStorm 2021.3 (and the corresponding versions of other IDEs), the Deno plugin uses the LSP ([WEB-48625](https://youtrack.jetbrains.com/issue/WEB-48625)).

Additionally, it uses the output of `deno types` instead of the bundled file.

You may want to wait with merging until WebStorm 2021.3 is officially released, that's why I created the PR as a draft.