### PR TITLE
fix(docs):update the URL for downloading neovim nightly

### DIFF
--- a/getting_started/setup_your_environment.md
+++ b/getting_started/setup_your_environment.md
@@ -70,9 +70,10 @@ also supports Deno.
 
 ##### Neovim 0.6+ and nvim-lspconfig
 
-Neovim has supported Deno's language server since version 0.5, but recent changes to Deno
-mean that now Neovim 0.6 or newer is needed. Until the release of 0.6 stable you
-must [install the pre-release version](https://github.com/neovim/neovim/releases).
+Neovim has supported Deno's language server since version 0.5, but recent
+changes to Deno mean that now Neovim 0.6 or newer is needed. Until the release
+of 0.6 stable you must
+[install the pre-release version](https://github.com/neovim/neovim/releases).
 
 To use the Deno language server install
 [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/) and follow the

--- a/getting_started/setup_your_environment.md
+++ b/getting_started/setup_your_environment.md
@@ -70,10 +70,9 @@ also supports Deno.
 
 ##### Neovim 0.6+ and nvim-lspconfig
 
-Neovim's built-in LSP has supported Deno since 0.5, but recent changes to Deno
+Neovim has supported Deno's language server since version 0.5, but recent changes to Deno
 mean that now Neovim 0.6 or newer is needed. Until the release of 0.6 stable you
-must install the nightly. Please see the
-[instructions on how to download the nightly release](https://github.com/neovim/neovim/issues/15709).
+must [install the pre-release version](https://github.com/neovim/neovim/releases).
 
 To use the Deno language server install
 [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/) and follow the


### PR DESCRIPTION
The old link to the Neovim nightly was only temporary until https://github.com/neovim/neovim/issues/15709 was closed.