### PR TITLE
chore: remove duplicate angular bracket in repl.md

### DIFF
--- a/tools/repl.md
+++ b/tools/repl.md
@@ -29,7 +29,7 @@ exit using ctrl+d or close()
 "hello world!"
 > _
 "hello world!"
-> > const foo = "bar";
+> const foo = "bar";
 undefined
 > _
 undefined


### PR DESCRIPTION
The line `> > const foo = "bar";` throws `parse error: Expected ';', '}' or <eof> at 1:9` because of a duplicate `>`