### PR TITLE
fix: update import name to assertStringIncludes

### DIFF
--- a/linking_to_external_code.md
+++ b/linking_to_external_code.md
@@ -67,7 +67,7 @@ create a `deps.ts` file that exports the third-party code:
 export {
   assert,
   assertEquals,
-  assertStringIncludes
+  assertStringIncludes,
 } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
 ```
 

--- a/linking_to_external_code.md
+++ b/linking_to_external_code.md
@@ -67,7 +67,7 @@ create a `deps.ts` file that exports the third-party code:
 export {
   assert,
   assertEquals,
-  assertStrContains,
+  assertStringIncludes
 } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
 ```
 


### PR DESCRIPTION
`assertStrContains` was removed a while ago in place of `assertStringIncludes`