### PR TITLE
fix(docs): fix link in setup_your_environment.md

### DIFF
--- a/getting_started/setup_your_environment.md
+++ b/getting_started/setup_your_environment.md
@@ -78,7 +78,7 @@ of 0.6 stable you must
 To use the Deno language server install
 [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/) and follow the
 instructions to enable the
-[supplied Deno configuration](https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md#denols).
+[supplied Deno configuration](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#denols).
 
 Deno's linting is not supported out of the box, but assuming you are using the
 `on_attach` helper function from the


### PR DESCRIPTION
In `setup_your_environment.md`, https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md is moved to https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md now.
