### PR TITLE
chore: update examples to use non-deprecated copy function

### DIFF
--- a/examples/tcp_echo.md
+++ b/examples/tcp_echo.md
@@ -5,7 +5,7 @@
 - Listening for TCP port connections with
   [Deno.listen](https://doc.deno.land/builtin/stable#Deno.listen).
 - Use
-  [copy](https://doc.deno.land/https/deno.land/std@$STD_VERSION/io/util.ts#copy)
+  [copy](https://doc.deno.land/https/deno.land/std@$STD_VERSION/streams/conversion.ts#copy)
   to take inbound data and redirect it to be outbound data.
 
 ## Example
@@ -17,7 +17,7 @@ returns to the client anything it sends.
 /**
  * echo_server.ts
  */
-import { copy } from "https://deno.land/std@$STD_VERSION/io/util.ts";
+import { copy } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
 const listener = Deno.listen({ port: 8080 });
 console.log("listening on 0.0.0.0:8080");
 for await (const conn of listener) {

--- a/getting_started/first_steps.md
+++ b/getting_started/first_steps.md
@@ -86,7 +86,7 @@ In this program each command-line argument is assumed to be a filename, the file
 is opened, and printed to stdout.
 
 ```ts
-import { copy } from "https://deno.land/std@$STD_VERSION/io/util.ts";
+import { copy } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
 const filenames = Deno.args;
 for (const filename of filenames) {
   const file = await Deno.open(filename);
@@ -116,7 +116,7 @@ This is an example of a server which accepts connections on port 8080, and
 returns to the client anything it sends.
 
 ```ts
-import { copy } from "https://deno.land/std@$STD_VERSION/io/util.ts";
+import { copy } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
 const hostname = "0.0.0.0";
 const port = 8080;
 const listener = Deno.listen({ hostname, port });


### PR DESCRIPTION
`copy` from `io/util.ts` was deprecated in favor of `copy` in `streams/conversion.ts`