### PR TITLE
fix docs(permission_apis.md): small typo

### DIFF
--- a/runtime/permission_apis.md
+++ b/runtime/permission_apis.md
@@ -168,7 +168,7 @@ to:
 
 Deno's permission revocation algorithm works by removing every element from this
 set which the argument permission descriptor is _stronger than_. So to ensure
-`desc` is not longer granted, pass an argument descriptor _stronger than_
+`desc` is no longer granted, pass an argument descriptor _stronger than_
 whichever _explicitly granted permission descriptor_ is _stronger than_ `desc`.
 
 ```ts


### PR DESCRIPTION
fix small typo in manual/runtime/permission_apis.md
The use of "no longer" vs "not longer" is debatable but in this context, I think the better option for readability is "no longer" since it is followed by an adjectivized verb.