### PR TITLE
Fixed link with redundant npm_nodejs path

### DIFF
--- a/npm_nodejs/std_node.md
+++ b/npm_nodejs/std_node.md
@@ -2,7 +2,7 @@
 
 > ⚠️ Starting with v1.15 Deno provides a compatiblity mode, that allows to
 > emulate Node.js environment and consume code authored for Node.js directly.
-> See [Node.js compability mode](./npm_nodejs/compatibility_mode.md) chapter for
+> See [Node.js compability mode](./compatibility_mode.md) chapter for
 > details.
 
 The `std/node` part of the Deno standard library is a Node.js compatibility

--- a/npm_nodejs/std_node.md
+++ b/npm_nodejs/std_node.md
@@ -2,8 +2,7 @@
 
 > ⚠️ Starting with v1.15 Deno provides a compatiblity mode, that allows to
 > emulate Node.js environment and consume code authored for Node.js directly.
-> See [Node.js compability mode](./compatibility_mode.md) chapter for
-> details.
+> See [Node.js compability mode](./compatibility_mode.md) chapter for details.
 
 The `std/node` part of the Deno standard library is a Node.js compatibility
 layer. Its primary focus is providing "polyfills" for Node.js's


### PR DESCRIPTION
Fixing the current 404 error in the production manual on https://deno.land/manual@v1.16.4/npm_nodejs/std_node