### PR TITLE
remove assertThrowsAsync in favor of assertRejects

### DIFF
--- a/testing/assertions.md
+++ b/testing/assertions.md
@@ -205,7 +205,7 @@ This can be used similar to `assertThrows` but with async functions.
 
 ```js
 Deno.test("Test Assert Throws Async", () => {
-  assertRejects(
+  await assertRejects(
     () => {
       return new Promise(() => {
         throw new Error("Panic! Threw Error");
@@ -215,7 +215,7 @@ Deno.test("Test Assert Throws Async", () => {
     "Panic! Threw Error",
   );
 
-  assertRejects(
+  await assertRejects(
     () => {
       return Promise.reject(new Error("Panic! Reject Error"));
     },

--- a/testing/assertions.md
+++ b/testing/assertions.md
@@ -173,8 +173,7 @@ assertObjectMatch(
 ### Throws
 
 There are two ways to assert whether something throws an error in Deno,
-`assertThrows()` and `assertRejects()`. Both assertions allow you to check
-an
+`assertThrows()` and `assertRejects()`. Both assertions allow you to check an
 [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error)
 has been thrown, the type of error thrown and what the message was.
 
@@ -198,10 +197,10 @@ Deno.test("Test Assert Throws", () => {
 });
 ```
 
-The `assertRejects()` assertion is a little more complicated, mainly because
-it deals with Promises. But basically it will catch thrown errors or rejections
-in Promises. You can also optionally check for the error type and error message.
-This can be used similar to `assertThrows` but with async functions.
+The `assertRejects()` assertion is a little more complicated, mainly because it
+deals with Promises. But basically it will catch thrown errors or rejections in
+Promises. You can also optionally check for the error type and error message.
+This can be used similar to `assertThrows()` but with async functions.
 
 ```js
 Deno.test("Test Assert Throws Async", () => {

--- a/testing/assertions.md
+++ b/testing/assertions.md
@@ -28,8 +28,8 @@ The assertions module provides 10 assertions:
 - `assertMatch(actual: string, expected: RegExp, msg?: string): void`
 - `assertNotMatch(actual: string, expected: RegExp, msg?: string): void`
 - `assertObjectMatch( actual: Record<PropertyKey, unknown>, expected: Record<PropertyKey, unknown>): void`
-- `assertThrows(fn: () => void, ErrorClass?: Constructor, msgIncludes = "", msg?: string): Error`
-- `assertThrowsAsync(fn: () => Promise<void>, ErrorClass?: Constructor, msgIncludes = "", msg?: string): Promise<Error>`
+- `assertThrows(fn: () => void, ErrorClass?: Constructor, msgIncludes?: string | undefined, msg?: string | undefined): Error`
+- `assertRejects(fn: () => Promise<unknown>, ErrorClass?: Constructor, msgIncludes?: string | undefined, msg?: string | undefined): Promise<void>`
 
 ### Assert
 
@@ -173,13 +173,13 @@ assertObjectMatch(
 ### Throws
 
 There are two ways to assert whether something throws an error in Deno,
-`assertThrows()` and `assertThrowsAsync()`. Both assertions allow you to check
+`assertThrows()` and `assertRejects()`. Both assertions allow you to check
 an
 [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error)
 has been thrown, the type of error thrown and what the message was.
 
 The difference between the two assertions is `assertThrows()` accepts a standard
-function and `assertThrowsAsync()` accepts a function which returns a
+function and `assertRejects()` accepts a function which returns a
 [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 
 The `assertThrows()` assertion will check an error has been thrown, and
@@ -198,13 +198,14 @@ Deno.test("Test Assert Throws", () => {
 });
 ```
 
-The `assertThrowsAsync()` assertion is a little more complicated, mainly because
+The `assertRejects()` assertion is a little more complicated, mainly because
 it deals with Promises. But basically it will catch thrown errors or rejections
 in Promises. You can also optionally check for the error type and error message.
+This can be used similar to `assertThrows` but with async functions.
 
 ```js
 Deno.test("Test Assert Throws Async", () => {
-  assertThrowsAsync(
+  assertRejects(
     () => {
       return new Promise(() => {
         throw new Error("Panic! Threw Error");
@@ -214,7 +215,7 @@ Deno.test("Test Assert Throws Async", () => {
     "Panic! Threw Error",
   );
 
-  assertThrowsAsync(
+  assertRejects(
     () => {
       return Promise.reject(new Error("Panic! Reject Error"));
     },


### PR DESCRIPTION
per https://github.com/denoland/deno_std/pull/1646 and https://github.com/denoland/deno_std/issues/1562 assertThrowsAsync has been removed, thus updating the manual