### PR TITLE
docs(configuration): add missing row for `useUnknownInCatchVariables`

### DIFF
--- a/typescript/configuration.md
+++ b/typescript/configuration.md
@@ -69,6 +69,7 @@ and any other notes about that option:
 | `strictNullChecks`               | `true`                  |                                                                                                                                                                                                                                                                                  |
 | `suppressExcessPropertyErrors`   | `false`                 |                                                                                                                                                                                                                                                                                  |
 | `suppressImplicitAnyIndexErrors` | `false`                 |                                                                                                                                                                                                                                                                                  |
+| `useUnknownInCatchVariables`     | `false`                 |                                                                                                                                                                                                                                                                                  |
 
 For a full list of compiler options and how they affect TypeScript, please refer
 to the


### PR DESCRIPTION
Closes #216 

From [#11826](https://github.com/denoland/deno/issues/11826), `useUnknownInCatchVariables` is default `false` in Deno.