### PR TITLE
Fixed potential typing mistake

### DIFF
--- a/examples/os_signals.md
+++ b/examples/os_signals.md
@@ -38,7 +38,7 @@ Deno.addSignalListener("SIGINT", (_) => {
   Deno.exit();
 });
 
-// Add a timeout to prevent process existing immediately.
+// Add a timeout to prevent process exiting immediately.
 setTimeout(() => {}, 5000);
 ```
 
@@ -91,7 +91,7 @@ import { signal } from "https://deno.land/std@$STD_VERSION/signal/mod.ts";
 
 const sig = signal("SIGUSR1", "SIGINT");
 
-// Add a timeout to prevent process existing immediately.
+// Add a timeout to prevent process exiting immediately.
 setTimeout(() => {}, 5000);
 
 for await (const _ of sig) {


### PR DESCRIPTION
Changed `existing` to `exiting` in line 41 and 94.
`setTimeout` is called to keep the program from exiting but not to delay existence.