### PR TITLE
fix(runtime/ffi_api): wrong paths for C examples

### DIFF
--- a/runtime/ffi_api.md
+++ b/runtime/ffi_api.md
@@ -35,10 +35,10 @@ And compile it:
 
 ```sh
 // unix
-cc -c -o add_numbers.o add_numbers.c
-cc -shared -Wl -o add_numbers.so add_numbers.o
+cc -c -o add.o add.c
+cc -shared -W -o libadd.so add.o
 // Windows
-cl /LD add_numbers.c /link /EXPORT:add_numbers
+cl /LD add.c /link /EXPORT:libadd
 ```
 
 Calling the library from Deno:


### PR DESCRIPTION
The C example file is refered as `// add.c`, but the commands compilations examples use `add_numbers.c` instead.
Additionally, the `.ts` use `libadd` as lib path so it doesn't work out of the box when you try it 

Also `-Wl` may be a typo because it throws the following:
```ts
cc: error: unrecognized command line option ‘-Wl’; did you mean ‘-W’?
```
Just using `-W` is fine though