### PR TITLE
Fix "Test sanitizers" sample code

### DIFF
--- a/testing/sanitizers.md
+++ b/testing/sanitizers.md
@@ -36,8 +36,8 @@ disabled by setting the `sanitizeOps` boolean to false in the test definition.
 Deno.test({
   name: "leaky operation test",
   fn() {
-    setTimeout(function () {}, 1000);
-  },
+    crypto.subtle.digest('SHA-256', new TextEncoder().encode("a".repeat(100000000)));
+  },  
   sanitizeOps: false,
 });
 ```

--- a/testing/sanitizers.md
+++ b/testing/sanitizers.md
@@ -36,8 +36,11 @@ disabled by setting the `sanitizeOps` boolean to false in the test definition.
 Deno.test({
   name: "leaky operation test",
   fn() {
-    crypto.subtle.digest('SHA-256', new TextEncoder().encode("a".repeat(100000000)));
-  },  
+    crypto.subtle.digest(
+      "SHA-256",
+      new TextEncoder().encode("a".repeat(100000000)),
+    );
+  },
   sanitizeOps: false,
 });
 ```

--- a/testing/sanitizers.md
+++ b/testing/sanitizers.md
@@ -19,7 +19,7 @@ boolean to false in the test definition.
 Deno.test({
   name: "leaky resource test",
   async fn() {
-    await Deno.open("hello.txt");
+    setTimeout(function () {}, 1000);
   },
   sanitizeResources: false,
 });
@@ -36,7 +36,7 @@ disabled by setting the `sanitizeOps` boolean to false in the test definition.
 Deno.test({
   name: "leaky operation test",
   fn() {
-    setTimeout(function () {}, 1000);
+    await Deno.open("hello.txt");
   },
   sanitizeOps: false,
 });

--- a/testing/sanitizers.md
+++ b/testing/sanitizers.md
@@ -19,7 +19,7 @@ boolean to false in the test definition.
 Deno.test({
   name: "leaky resource test",
   async fn() {
-    setTimeout(function () {}, 1000);
+    await Deno.open("hello.txt");
   },
   sanitizeResources: false,
 });
@@ -36,7 +36,7 @@ disabled by setting the `sanitizeOps` boolean to false in the test definition.
 Deno.test({
   name: "leaky operation test",
   fn() {
-    await Deno.open("hello.txt");
+    setTimeout(function () {}, 1000);
   },
   sanitizeOps: false,
 });


### PR DESCRIPTION
I think the sample code in testing/sanitizers.md is different.

Resource sanitizer is `setTimeout` and Op sanitizer is `Deno.open`.