### PR TITLE
docs(setup): Minor edit

### DIFF
--- a/getting_started/setup_your_environment.md
+++ b/getting_started/setup_your_environment.md
@@ -388,7 +388,7 @@ deno completions fish > ~/.config/fish/completions/deno.fish
 
 ### Environment variables
 
-There are a few environment variables which can impact the behavior of Deno:
+There are several environment variables which can impact the behavior of Deno:
 
 - `DENO_AUTH_TOKENS` - a list of authorization tokens which can be used to allow
   Deno to access remote private code. See the

--- a/getting_started/setup_your_environment.md
+++ b/getting_started/setup_your_environment.md
@@ -388,7 +388,7 @@ deno completions fish > ~/.config/fish/completions/deno.fish
 
 ### Environment variables
 
-There are a couple environment variables which can impact the behavior of Deno:
+There are a few environment variables which can impact the behavior of Deno:
 
 - `DENO_AUTH_TOKENS` - a list of authorization tokens which can be used to allow
   Deno to access remote private code. See the


### PR DESCRIPTION
Nitpick from: ['Couple,' 'Few,' and 'Several': The (Mostly) Definitive Guide](https://www.merriam-webster.com/words-at-play/couple-few-several-use)

> Couple is used when referring to two things, as in "a couple of days ago," whereas few and several are less specific. Few means "not many but some," as in "The train leaves in a few minutes," and several denotes more than the words couple and few do but implies lesser than the word many does.