### PR TITLE
fix: typo in Deno.upgradeWebSocket example

### DIFF
--- a/runtime/http_server_apis.md
+++ b/runtime/http_server_apis.md
@@ -174,7 +174,7 @@ function handler(req: Request): Response {
   const upgrade = req.headers.get("upgrade") || "";
   let socket, response;
   try {
-    res = Deno.upgradeWebSocket(req);
+    const res = Deno.upgradeWebSocket(req);
     socket = res.socket;
     response = res.response;
   } catch {

--- a/runtime/http_server_apis.md
+++ b/runtime/http_server_apis.md
@@ -172,11 +172,9 @@ Documentation for it can be found
 ```ts
 function handler(req: Request): Response {
   const upgrade = req.headers.get("upgrade") || "";
-  let socket, response;
+  let response, socket;
   try {
-    const res = Deno.upgradeWebSocket(req);
-    socket = res.socket;
-    response = res.response;
+    ({ response, socket }  = Deno.upgradeWebSocket(req));
   } catch {
     return new Response("request isn't trying to upgrade to websocket.");
   }

--- a/runtime/http_server_apis.md
+++ b/runtime/http_server_apis.md
@@ -174,7 +174,7 @@ function handler(req: Request): Response {
   const upgrade = req.headers.get("upgrade") || "";
   let response, socket;
   try {
-    ({ response, socket }  = Deno.upgradeWebSocket(req));
+    ({ response, socket } = Deno.upgradeWebSocket(req));
   } catch {
     return new Response("request isn't trying to upgrade to websocket.");
   }


### PR DESCRIPTION
This could also be:

```js
({ response, socket }  = Deno.upgradeWebSocket(req));
```

But that form of destructuring assignment might be less familiar to users