### PR TITLE
Fix broken sentence in intro #266

### DIFF
--- a/introduction.md
+++ b/introduction.md
@@ -16,8 +16,9 @@ It's built on V8, Rust, and Tokio.
 - Ships a single executable (`deno`).
 - Has built-in utilities like a code formatter (`deno fmt`), a linter
   (`deno lint`), and a test runner (`deno test`).
-- Has [a set of reviewed (audited) standard modules](https://github.com/denoland/deno_std) that are guaranteed to work
-  with Deno.
+- Has
+  [a set of reviewed (audited) standard modules](https://github.com/denoland/deno_std)
+  that are guaranteed to work with Deno.
 - Can bundle scripts into a single JavaScript file.
 
 ## Philosophy

--- a/introduction.md
+++ b/introduction.md
@@ -16,9 +16,7 @@ It's built on V8, Rust, and Tokio.
 - Ships a single executable (`deno`).
 - Has built-in utilities like a code formatter (`deno fmt`), a linter
   (`deno lint`), and a test runner (`deno test`).
-- Has
-  [a set of reviewed (audited) standard
-  library](https://github.com/denoland/deno_std) that are guaranteed to work
+- Has [a set of reviewed (audited) standard modules](https://github.com/denoland/deno_std) that are guaranteed to work
   with Deno.
 - Can bundle scripts into a single JavaScript file.
 


### PR DESCRIPTION
I fixed this issue to make the sentence corresponding with https://deno.land/manual@v1.12.2/introduction