### PR TITLE
fix: update ignore attrs to enable syntax highlighting

### DIFF
--- a/examples/manage_dependencies.md
+++ b/examples/manage_dependencies.md
@@ -50,7 +50,7 @@ local `deps.ts` module.
 
 **Command:** `deno run example.ts`
 
-```ts{ignore}
+```ts, ignore
 /**
  * example.ts
  */

--- a/jsx_dom/css.md
+++ b/jsx_dom/css.md
@@ -25,7 +25,7 @@ In this example, we will parse some CSS into an AST and make a modification to
 the `background` declaration of the `body` rule, to change the color to `white`.
 Then we will stringify the modified CSS AST and output it to the console:
 
-```ts ignore
+```ts, ignore
 import * as css from "https://esm.sh/css@3.0.0";
 import { assert } from "https://deno.land/std@0.132.0/testing/asserts.ts";
 

--- a/jsx_dom/jsdom.md
+++ b/jsx_dom/jsdom.md
@@ -64,7 +64,7 @@ This example will take a test string and parse it as HTML and generate a DOM
 structure based on it. It will then query that DOM structure, picking out the
 first heading it encounters and print out the text content of that heading:
 
-```ts ignore
+```ts, ignore
 import { JSDOM } from "jsdom";
 import { assert } from "https://deno.land/std@0.132.0/testing/asserts.ts";
 

--- a/jsx_dom/jsx.md
+++ b/jsx_dom/jsx.md
@@ -41,7 +41,7 @@ module that is expected to conform to the _new_ JSX API and is located at either
 `jsx-runtime` or `jsx-dev-runtime`. For example if a JSX import source is
 configured to `react`, then the emitted code will add this to the emitted file:
 
-```jsx ignore
+```jsx, ignore
 import { jsx as jsx_ } from "react/jsx-runtime";
 ```
 
@@ -66,7 +66,7 @@ pragma to a `.jsx` or `.tsx` module, and Deno will respect it.
 The `@jsxImportSource` pragma needs to be in the leading comments of the module.
 For example to use Preact from esm.sh, you would do something like this:
 
-```jsx ignore
+```jsx, ignore
 /** @jsxImportSource https://esm.sh/preact */
 
 export function App() {
@@ -115,7 +115,7 @@ like this:
 
 And then you could use the following pragma:
 
-```jsx ignore
+```jsx, ignore
 /** @jsxImportSource preact */
 ```
 

--- a/jsx_dom/linkedom.md
+++ b/jsx_dom/linkedom.md
@@ -64,7 +64,7 @@ similar to jsdom's `JSDOM()` function, in the sense it gives you a "sandbox" of
 a `window` scope you can use to access API's outside of the scope of the
 `document`. For example:
 
-```ts ignore
+```ts, ignore
 import { parseHTML } from "https://esm.sh/linkedom";
 
 const { document, customElements, HTMLElement } = parseHTML(`<!DOCTYPE html>


### PR DESCRIPTION
`ts ignore` works to exclude a block from type-checking but the site's markdown parser expects `ts, ignore`, otherwise the syntax highlighting will be missing: https://github.com/lucacasonato/deno-gfm/blob/5445765933f9db0fc019e824bfe0eef2fa3d109e/mod.ts#L18