### PR TITLE
doc: fix ReadableStream http server api example

### DIFF
--- a/runtime/http_server_apis.md
+++ b/runtime/http_server_apis.md
@@ -131,7 +131,7 @@ function handler(req: Request): Response {
       clearInterval(timer);
     },
   });
-  return new Response(body, {
+  return new Response(body.pipeThrough(new TextEncoderStream()), {
     headers: {
       "content-type": "text/plain; charset=utf-8",
     },


### PR DESCRIPTION
The documentation for the ReadableStream example is broken and doesn't return anything.  This change corrects this with the correct handling of the body, piping it through the TextEncoderStream.