### PR TITLE
chore(examples/file_server): use fast path for streams

### DIFF
--- a/examples/file_server.md
+++ b/examples/file_server.md
@@ -4,9 +4,7 @@
 
 - Use [Deno.open](https://doc.deno.land/deno/stable/~/Deno.open) to read a
   file's content in chunks.
-- Use the Deno standard library
-  [streams module](https://deno.land/std@$STD_VERSION/streams/) to transform a
-  Deno file into a
+- Transform a Deno file into a
   [ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
 - Use Deno's integrated HTTP server to run your own file server.
 

--- a/examples/file_server.md
+++ b/examples/file_server.md
@@ -22,15 +22,12 @@ memory.
 **Command:** `deno run --allow-read --allow-net file_server.ts`
 
 ```ts
-import * as path from "https://deno.land/std@$STD_VERSION/path/mod.ts";
-import { readableStreamFromReader } from "https://deno.land/std@$STD_VERSION/streams/mod.ts";
-
 // Start listening on port 8080 of localhost.
 const server = Deno.listen({ port: 8080 });
 console.log("File server running on http://localhost:8080/");
 
 for await (const conn of server) {
-  handleHttp(conn);
+  handleHttp(conn).catch(console.error);
 }
 
 async function handleHttp(conn: Deno.Conn) {
@@ -44,14 +41,6 @@ async function handleHttp(conn: Deno.Conn) {
     let file;
     try {
       file = await Deno.open("." + filepath, { read: true });
-      const stat = await file.stat();
-
-      // If File instance is a directory, lookup for an index.html
-      if (stat.isDirectory) {
-        file.close();
-        const filePath = path.join("./", filepath, "index.html");
-        file = await Deno.open(filePath, { read: true });
-      }
     } catch {
       // If the file cannot be opened, return a "404 Not Found" response
       const notFoundResponse = new Response("404 Not Found", { status: 404 });
@@ -61,7 +50,7 @@ async function handleHttp(conn: Deno.Conn) {
 
     // Build a readable stream so the file doesn't have to be fully loaded into
     // memory while we send it
-    const readableStream = readableStreamFromReader(file);
+    const readableStream = file.readable;
 
     // Build and send the response
     const response = new Response(readableStream);


### PR DESCRIPTION
Closes https://github.com/denoland/manual/issues/286

This is the fast path we are optimizing for in https://github.com/denoland/deno/pull/14284 (benchmark numbers are going to go up once it relands)

Also, removes the directory -> index.html handling... it's not really useful. best to defer to the optimized std/http/file_server for complex stuff.

`sample.txt` = 5MB

Earlier:
```
wrk -t8 -c20 -d10s http://localhost:8080/sample.txt
Running 10s test @ http://localhost:8080/sample.txt
  8 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    86.02ms    4.50ms 128.32ms   91.77%
    Req/Sec    23.30      7.36    40.00     84.00%
  1872 requests in 10.10s, 9.18GB read
Requests/sec:    185.35
Transfer/sec:      0.91GB
```

This PR:
```
wrk -t8 -c20 -d10s http://localhost:8080/sample.txt
Running 10s test @ http://localhost:8080/sample.txt
  8 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    37.26ms    2.79ms  78.34ms   95.77%
    Req/Sec    53.51      9.73    60.00     69.06%
  4324 requests in 10.10s, 21.18GB read
Requests/sec:    428.09
Transfer/sec:      2.10GB
```