### PR TITLE
Note not to use TLA in workers before setting the `message` listener

### DIFF
--- a/runtime/workers.md
+++ b/runtime/workers.md
@@ -25,6 +25,26 @@ new Worker(new URL("./worker.js", import.meta.url).href, { type: "classic" });
 new Worker("./worker.js", { type: "module" });
 ```
 
+As with regular modules, you can use top-level `await` in worker modules.
+However, you should be careful to always register the message handler before the
+first `await`, since messages can be lost otherwise. This is not a bug in Deno,
+it's just an unfortunate interaction of features, and it also happens in all
+browsers that support module workers.
+
+```ts
+import { delay } from "https://deno.land/std@0.136.0/async/mod.ts";
+
+// First await: waits for a second, then continues running the module.
+await delay(1000);
+
+// The message handler is only set after that 1s delay, so some of the messages
+// that reached the worker during that second might have been fired when no
+// handler was registered.
+self.onmessage = (evt) => {
+  console.log(evt.data);
+};
+```
+
 ### Instantiation permissions
 
 Creating a new `Worker` instance is similar to a dynamic import; therefore Deno

--- a/runtime/workers.md
+++ b/runtime/workers.md
@@ -31,7 +31,7 @@ first `await`, since messages can be lost otherwise. This is not a bug in Deno,
 it's just an unfortunate interaction of features, and it also happens in all
 browsers that support module workers.
 
-```ts
+```ts, ignore
 import { delay } from "https://deno.land/std@0.136.0/async/mod.ts";
 
 // First await: waits for a second, then continues running the module.


### PR DESCRIPTION
This is a somewhat common pain point which is not a bug, so it should be documented in the manual.

Closes #264.
