### PR TITLE
Fix Small Typos

### DIFF
--- a/publishing.md
+++ b/publishing.md
@@ -18,8 +18,8 @@ then be accessed by using a url in the following format:
 https://deno.land/x/<module_name>@<tag_name>/<file_path>
 ```
 
-Module versions are persistent and immutable. It is thus not possible to edit
-or delete a module (or version), to prevent breaking programs that rely on this
+Module versions are persistent and immutable. It is thus not possible to edit or
+delete a module (or version), to prevent breaking programs that rely on this
 module. Modules may be removed if there is a legal reason to do so (for example
 copyright infringement).
 

--- a/publishing.md
+++ b/publishing.md
@@ -18,7 +18,7 @@ then be accessed by using a url in the following format:
 https://deno.land/x/<module_name>@<tag_name>/<file_path>
 ```
 
-Module versions are persistent and immutable. It is thus not possible to editor
+Module versions are persistent and immutable. It is thus not possible to edit
 or delete a module (or version), to prevent breaking programs that rely on this
 module. Modules may be removed if there is a legal reason to do so (for example
 copyright infringement).

--- a/vscode_deno/testing_api.md
+++ b/vscode_deno/testing_api.md
@@ -78,7 +78,7 @@ have provided an explicit `--import-map` value in the testing args setting.
 ### Known limitations and caveats
 
 Because of the way the Deno test runner runs, it is not possible to exclude (or
-explicitly include) as as test step. While the vscode UI will allow you to do
+explicitly include) a test step. While the vscode UI will allow you to do
 this, by for example, choosing to run a specific test step, all test steps in
 that test will be run (but vscode will not update the results for them). So if
 there are other side effects in the test case, they may occur.

--- a/vscode_deno/testing_api.md
+++ b/vscode_deno/testing_api.md
@@ -78,7 +78,7 @@ have provided an explicit `--import-map` value in the testing args setting.
 ### Known limitations and caveats
 
 Because of the way the Deno test runner runs, it is not possible to exclude (or
-explicitly include) a test step. While the vscode UI will allow you to do
-this, by for example, choosing to run a specific test step, all test steps in
-that test will be run (but vscode will not update the results for them). So if
-there are other side effects in the test case, they may occur.
+explicitly include) a test step. While the vscode UI will allow you to do this,
+by for example, choosing to run a specific test step, all test steps in that
+test will be run (but vscode will not update the results for them). So if there
+are other side effects in the test case, they may occur.


### PR DESCRIPTION
I spotted two small typos in `testing_api.md` and `publishing.md`.