### PR TITLE
docs(runtime): in the FFI example, do not hardcode 'linux' for .so

### DIFF
--- a/runtime/ffi_api.md
+++ b/runtime/ffi_api.md
@@ -56,7 +56,7 @@ switch (Deno.build.os) {
   case "darwin":
     libSuffix = "dylib";
     break;
-  case "linux":
+  default:
     libSuffix = "so";
     break;
 }


### PR DESCRIPTION
All ELF platforms (*BSD, solaris/illumos) use .so for libraries. Let's not teach people to hardcode Linux.