### PR TITLE
docs: add style guide about private fields

### DIFF
--- a/contributing/style_guide.md
+++ b/contributing/style_guide.md
@@ -368,3 +368,29 @@ of the module:
 Maintain browser compatibility for such a module by either not using the global
 `Deno` namespace or feature-testing for it. Make sure any new dependencies are
 also browser compatible.
+
+#### Prefer `#` over `private`
+
+We prefer the private fields (`#`) syntax over `private` keyword of TypeScript
+in the standard modules codebase. The private fields make the properties and
+methods private even at runtime. On the other hand, `private` keyword of
+TypeScript guarantee it private only at compile time and the fields are publicly
+accessbile at runtime.
+
+Good:
+
+```ts
+class MyClass {
+  #foo = 1;
+  #bar() {}
+}
+```
+
+Bad:
+
+```ts
+class MyClass {
+  private foo = 1;
+  private bar() {}
+}
+```


### PR DESCRIPTION
This was first suggested in this issue https://github.com/denoland/deno_std/issues/1649

Since most of us seem to prefer `#` over `private` keyword, I suggest we set this as an explicit rule.