### PR TITLE
docs(jsx_dom): Fix "Using LinkeDOM with Deno" link

### DIFF
--- a/jsx_dom.md
+++ b/jsx_dom.md
@@ -4,7 +4,7 @@ In this chapter we will discuss:
 
 - [Overview of JSX and DOM in Deno](./jsx_dom/overview.md)
 - [Configuring JSX in Deno](./jsx_dom/jsx.md)
-- [Using LinkeDOM with Deno](./jsx_dom/LinkeDOM.md)
+- [Using LinkeDOM with Deno](./jsx_dom/linkedom.md)
 - [Using deno-dom with Deno](./jsx_dom/deno_dom.md)
 - [Using JSDOM with Deno](./jsx_dom/jsdom.md)
 - [Parsing and stringifying CSS](./jsx_dom/css.md)


### PR DESCRIPTION
Fixing part of https://github.com/denoland/dotland/issues/2128.