### PR TITLE
Update deno workers page that they dont work in compiled executables

### DIFF
--- a/runtime/workers.md
+++ b/runtime/workers.md
@@ -9,6 +9,8 @@ is run on a separate thread, dedicated only to that worker.
 Currently Deno supports only `module` type workers; thus it's essential to pass
 the `type: "module"` option when creating a new worker.
 
+Workers currently do not work in compiled executebles.
+
 Use of relative module specifiers in the main worker are only supported with
 `--location <href>` passed on the CLI. This is not recommended for portability.
 You can instead use the `URL` constructor and `import.meta.url` to easily create


### PR DESCRIPTION
Added that Workers don't currently work in compiled executables to save people from finding out the hard way.