### PR TITLE
fix issue with code sample in ffi for compiling add.c in windows

### DIFF
--- a/runtime/ffi_api.md
+++ b/runtime/ffi_api.md
@@ -38,7 +38,7 @@ And compile it:
 cc -c -o add.o add.c
 cc -shared -W -o libadd.so add.o
 // Windows
-cl /LD add.c /link /EXPORT:libadd
+cl /LD add.c /link /EXPORT:add
 ```
 
 Calling the library from Deno:


### PR DESCRIPTION
Fixes this issue https://github.com/denoland/deno_doc/issues/253