### PR TITLE
fix: remove invalid link to compiler APIs page

### DIFF
--- a/runtime/compiler_apis.md
+++ b/runtime/compiler_apis.md
@@ -1,4 +1,0 @@
-## Compiler APIs
-
-> ℹ️ This section has been moved to
-> [TypeScript Runtime APIs](../typescript/runtime.md).

--- a/typescript.md
+++ b/typescript.md
@@ -6,5 +6,4 @@ In this chapter we will discuss:
 - [Configuring TypeScript in Deno](./typescript/configuration.md)
 - [Types and Type Declarations](./typescript/types.md)
 - [Migrating to/from JavaScript](./typescript/migration.md)
-- [Runtime compiler APIs](./typescript/runtime.md)
 - [FAQs about TypeScript in Deno](./typescript/faqs.md)


### PR DESCRIPTION
Fixes #326

The page was linking to a page that was removed as part of #319.

Edit: already removed from TOC