### PR TITLE
Add note about `importMap` option in config file

### DIFF
--- a/getting_started/configuration_file.md
+++ b/getting_started/configuration_file.md
@@ -31,6 +31,7 @@ file is planned for the upcoming releases.
     "lib": ["deno.window"],
     "strict": true
   },
+  "importMap": "import_map.json",
   "lint": {
     "files": {
       "include": ["src/"],

--- a/introduction.md
+++ b/introduction.md
@@ -13,12 +13,12 @@ It's built on V8, Rust, and Tokio.
   support `fetch()`.
 - Secure by default. No file, network, or environment access unless explicitly
   enabled.
-- Supports [TypeScript](./typescript/) out of the box.
+- Supports [TypeScript](./typescript.md) out of the box.
 - Ships a single executable (`deno`).
-- Provides built-in [development tooling](./tools) like a code formatter
+- Provides built-in [development tooling](./tools.md) like a code formatter
   ([`deno fmt`](./tools/formatter.md)), a linter
-  ([`deno lint`](./tools/linter.md)), a test runner ([`deno test`](./testing)),
-  and a
+  ([`deno lint`](./tools/linter.md)), a test runner
+  ([`deno test`](./testing.md)), and a
   [language server for your editor](./getting_started/setup_your_environment.md#using-an-editoride).
 - Has
   [a set of reviewed (audited) standard modules](https://doc.deno.land/https://deno.land/std/)

--- a/introduction.md
+++ b/introduction.md
@@ -13,12 +13,12 @@ It's built on V8, Rust, and Tokio.
   support `fetch()`.
 - Secure by default. No file, network, or environment access unless explicitly
   enabled.
-- Supports [TypeScript](./typescript.md) out of the box.
+- Supports [TypeScript](./typescript/) out of the box.
 - Ships a single executable (`deno`).
-- Provides built-in [development tooling](./tools.md) like a code formatter
+- Provides built-in [development tooling](./tools) like a code formatter
   ([`deno fmt`](./tools/formatter.md)), a linter
-  ([`deno lint`](./tools/linter.md)), a test runner
-  ([`deno test`](./testing.md)), and a
+  ([`deno lint`](./tools/linter.md)), a test runner ([`deno test`](./testing)),
+  and a
   [language server for your editor](./getting_started/setup_your_environment.md#using-an-editoride).
 - Has
   [a set of reviewed (audited) standard modules](https://doc.deno.land/https://deno.land/std/)

--- a/linking_to_external_code/import_maps.md
+++ b/linking_to_external_code/import_maps.md
@@ -2,7 +2,9 @@
 
 Deno supports [import maps](https://github.com/WICG/import-maps).
 
-You can use import maps with the `--import-map=<FILE>` CLI flag.
+You can use import maps with the `--import-map=<FILE>` CLI flag or `importMap`
+option in the [configuration file](../getting_started/configuration_file.md),
+the former will take precedence.
 
 Example:
 


### PR DESCRIPTION
Adding this to the manual so others don't have to read the JSON schema of config file in order to realize the existence of `importMap` option like me.

Also improved the links in Introduction page for GitHub a little bit.