### PR TITLE
docs(testing): Fix potentially confusing typo in Testing

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -293,7 +293,7 @@ Assuming the following tests:
 ```ts, ignore
 Deno.test({ name: "my-test", fn: myTest });
 Deno.test({ name: "test-1", fn: test1 });
-Deno.test({ name: "test2", fn: test2 });
+Deno.test({ name: "test-2", fn: test2 });
 ```
 
 This command will run all of these tests because they all contain the word


### PR DESCRIPTION
Fix typo in `deno test --filter` example that may cause confusion in regex pattern matching. Assertion on line 306 is not currently true