### PR TITLE
fix: link not pointing to the right location

### DIFF
--- a/introduction.md
+++ b/introduction.md
@@ -20,8 +20,7 @@ It's built on V8, Rust, and Tokio.
   ([`deno lint`](./tools/linter.md)), a test runner ([`deno test`](./testing)),
   and a
   [language server for your editor](./getting_started/setup_your_environment.md#using-an-editoride).
-- Has
-  [a set of reviewed (audited) standard modules](https://deno.land/std/)
+- Has [a set of reviewed (audited) standard modules](https://deno.land/std/)
   that are guaranteed to work with Deno.
 - Can [bundle](./tools/bundler.md) scripts into a single JavaScript file or
   [executable](./tools/compiler.md).

--- a/introduction.md
+++ b/introduction.md
@@ -21,7 +21,7 @@ It's built on V8, Rust, and Tokio.
   and a
   [language server for your editor](./getting_started/setup_your_environment.md#using-an-editoride).
 - Has
-  [a set of reviewed (audited) standard modules](https://doc.deno.land/https://deno.land/std/)
+  [a set of reviewed (audited) standard modules](https://deno.land/std/)
   that are guaranteed to work with Deno.
 - Can [bundle](./tools/bundler.md) scripts into a single JavaScript file or
   [executable](./tools/compiler.md).


### PR DESCRIPTION
Now it properly takes you to the https://deno.land/std/ instead of showing this:
```
Bad Request
Bad request: Module not found "https://deno.land/std@0.146.0".
```