### PR TITLE
ci: add canary run to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,22 @@ jobs:
 
   type-check:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.canary }}
+    strategy:
+      matrix:
+        deno-version: [ v1.x ]
+        canary: [ false ]
+        include:
+          - deno-version: canary
+            canary: true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Deno
         uses: denoland/setup-deno@v1.0.0
+        with:
+          deno-version: ${{ matrix.deno-version }}
         
       - name: Type-check Deno manual
         run: deno test --doc --unstable --import-map=.github/import_map.json --no-check=remote


### PR DESCRIPTION
Sometimes the type-check step fails after a release because of changes to TypeScript types. This PR adds a workflow run on the canary release of Deno so that these errors may be spotted earlier. The canary run has `continue-on-error: true` configured so if it fails it will not cause the CI to fail.

This PR is very much a suggestion because there are other solutions too, like triggering the pipeline anytime a new tag of the deno docker image is released or something along those lines. With the solution in this PR there is still a chance that type-check failures go unnoticed if the manual's pipeline has not run for a while.