### PR TITLE
docs(getting_started): Add subsection for type-checking instructions

### DIFF
--- a/getting_started/command_line_interface.md
+++ b/getting_started/command_line_interface.md
@@ -100,7 +100,7 @@ depend on the subcommand used:
 Whenever one of the watched files is changed on disk, the program will
 automatically be restarted / formatted / tested / bundled.
 
-```
+```shell
 deno run --watch main.ts
 deno test --watch
 deno fmt --watch
@@ -111,7 +111,7 @@ deno fmt --watch
 Affect commands which can download resources to the cache: `deno cache`,
 `deno run`, `deno test`, `deno bundle`, `deno doc`, and `deno compile`.
 
-```
+```terminal
 --lock <FILE>    Check the specified lock file
 --lock-write     Write lock file. Use with --lock.
 ```
@@ -126,7 +126,7 @@ Affect commands which can populate the cache: `deno cache`, `deno run`,
 above, this includes those which affect module resolution, compilation
 configuration etc.
 
-```
+```terminal
 --config <FILE>               Load configuration file
 --import-map <FILE>           Load import map file
 --no-remote                   Do not resolve remote modules
@@ -147,7 +147,7 @@ These are listed [here](./permissions.md#permissions-list).
 
 More flags which affect the execution environment.
 
-```
+```terminal
 --cached-only                Require that remote dependencies are already cached
 --inspect=<HOST:PORT>        activate inspector on host:port ...
 --inspect-brk=<HOST:PORT>    activate inspector on host:port and break at ...

--- a/getting_started/command_line_interface.md
+++ b/getting_started/command_line_interface.md
@@ -147,13 +147,18 @@ You can type-check your code (without executing it) using the command:
 > deno check main.ts
 ```
 
-You can also type-check your code before execution by using the `--check` argument to deno run:
+You can also type-check your code before execution by using the `--check`
+argument to deno run:
 
 ```shell
 > deno run --check main.ts
 ```
 
-This flag affects `deno run`, `deno eval`, `deno repl` and `deno cache`. The following table describes the type-checking behavior of various subcommands. Here "Local" means that only errors from local code will induce type-errors, modules imported from https URLs (remote) may have type errors that are not reported. (To turn on type-checking for all modules, use `--check=all`.)
+This flag affects `deno run`, `deno eval`, `deno repl` and `deno cache`. The
+following table describes the type-checking behavior of various subcommands.
+Here "Local" means that only errors from local code will induce type-errors,
+modules imported from https URLs (remote) may have type errors that are not
+reported. (To turn on type-checking for all modules, use `--check=all`.)
 
 | Subcommand     | Type checking mode |
 | -------------- | ------------------ |

--- a/getting_started/command_line_interface.md
+++ b/getting_started/command_line_interface.md
@@ -139,6 +139,34 @@ configuration etc.
 Affect commands which execute user code: `deno run` and `deno test`. These
 include all of the above as well as the following.
 
+#### Type checking flags
+
+You can type-check your code (without executing it) using the command:
+
+```shell
+> deno check main.ts
+```
+
+You can also type-check your code before execution by using the `--check` argument to deno run:
+
+```shell
+> deno run --check main.ts
+```
+
+This flag affects `deno run`, `deno eval`, `deno repl` and `deno cache`. The following table describes the type-checking behavior of various subcommands. Here "Local" means that only errors from local code will induce type-errors, modules imported from https URLs (remote) may have type errors that are not reported. (To turn on type-checking for all modules, use `--check=all`.)
+
+| Subcommand     | Type checking mode |
+| -------------- | ------------------ |
+| `deno bench`   | 📁 Local            |
+| `deno bundle`  | 📁 Local            |
+| `deno cache`   | ❌ None             |
+| `deno check`   | 📁 Local            |
+| `deno compile` | 📁 Local            |
+| `deno eval`    | ❌ None             |
+| `deno repl`    | ❌ None             |
+| `deno run`     | ❌ None             |
+| `deno test`    | 📁 Local            |
+
 #### Permission flags
 
 These are listed [here](./permissions.md#permissions-list).

--- a/getting_started/setup_your_environment.md
+++ b/getting_started/setup_your_environment.md
@@ -278,7 +278,7 @@ stdout the completions. Current shells that are supported:
 
 Output the completions and add them to the environment:
 
-```
+```shell
 > deno completions bash > /usr/local/etc/bash_completion.d/deno.bash
 > source /usr/local/etc/bash_completion.d/deno.bash
 ```
@@ -287,7 +287,7 @@ Output the completions and add them to the environment:
 
 Output the completions:
 
-```
+```shell
 > deno completions powershell >> $profile
 > .$profile
 ```
@@ -300,13 +300,13 @@ will be run whenever you launch the PowerShell.
 
 You should have a directory where the completions can be saved:
 
-```
+```shell
 > mkdir ~/.zsh
 ```
 
 Then output the completions:
 
-```
+```shell
 > deno completions zsh > ~/.zsh/_deno
 ```
 
@@ -330,7 +330,7 @@ zsh and can make it easier to manage your shell configuration.
 
 Create the directory to store the completions and output the completions:
 
-```
+```shell
 > mkdir ~/.oh-my-zsh/custom/plugins/deno
 > deno completions zsh > ~/.oh-my-zsh/custom/plugins/deno/_deno
 ```
@@ -352,7 +352,7 @@ Output the completions to a `deno.fish` file into the completions directory in
 the fish config folder:
 
 ```shell
-deno completions fish > ~/.config/fish/completions/deno.fish
+> deno completions fish > ~/.config/fish/completions/deno.fish
 ```
 
 ### Environment variables
@@ -396,7 +396,7 @@ There are several environment variables which can impact the behavior of Deno:
   [Proxies](../linking_to_external_code/proxies.md) section for more
   information.
 - `NO_COLOR` - If set, this will cause the Deno CLI to not send ANSI color codes
-  when writing to stdout and stderr. See the website https://no-color.org/ for
+  when writing to stdout and stderr. See the website <https://no-color.org/> for
   more information on this _de facto_ standard. The value of this flag can be
   accessed at runtime without permission to read the environment variables by
   checking the value of `Deno.noColor`.

--- a/getting_started/setup_your_environment.md
+++ b/getting_started/setup_your_environment.md
@@ -388,8 +388,6 @@ There are several environment variables which can impact the behavior of Deno:
   are stored. This defaults to `$HOME/.deno/bin`.
 - `DENO_NO_PROMPT` - Set to disable permission prompts on access (alternative to
   passing `--no-prompt` on invocation).
-- `DENO_FUTURE_CHECK` - Opt-in to the upcoming behavior of the `deno run`
-  subcommand that doesn't perform type-checking by default.
 - `DENO_WEBGPU_TRACE` - The directory to use for WebGPU traces.
 - `HTTP_PROXY` - The proxy address to use for HTTP requests. See the
   [Proxies](../linking_to_external_code/proxies.md) section for more


### PR DESCRIPTION
Issue: https://github.com/denoland/manual/issues/348

This PR updates the `getting_started` section to incorporate changes from **v1.23** regarding type-checking by default.
