### PR TITLE
Fix Introduction links on GitHub

### DIFF
--- a/introduction.md
+++ b/introduction.md
@@ -13,12 +13,12 @@ It's built on V8, Rust, and Tokio.
   support `fetch()`.
 - Secure by default. No file, network, or environment access unless explicitly
   enabled.
-- Supports [TypeScript](./typescript/) out of the box.
+- Supports [TypeScript](./typescript.md) out of the box.
 - Ships a single executable (`deno`).
-- Provides built-in [development tooling](./tools) like a code formatter
+- Provides built-in [development tooling](./tools.md) like a code formatter
   ([`deno fmt`](./tools/formatter.md)), a linter
-  ([`deno lint`](./tools/linter.md)), a test runner ([`deno test`](./testing)),
-  and a
+  ([`deno lint`](./tools/linter.md)), a test runner
+  ([`deno test`](./testing.md)), and a
   [language server for your editor](./getting_started/setup_your_environment.md#using-an-editoride).
 - Has
   [a set of reviewed (audited) standard modules](https://doc.deno.land/https://deno.land/std/)


### PR DESCRIPTION
Fix some links in Introduction page so they point to the correct files on GitHub. After https://github.com/denoland/dotland/pull/2177 is merged there will also be zero redirect penalty.

From https://github.com/denoland/manual/pull/333#discussion_r913211947