### PR TITLE
fix: ignore if os isn’t windows

### DIFF
--- a/tools/benchmarker.md
+++ b/tools/benchmarker.md
@@ -238,7 +238,7 @@ skipped.
 ```ts
 Deno.bench({
   name: "bench windows feature",
-  ignore: Deno.build.os === "windows",
+  ignore: Deno.build.os !== "windows",
   fn() {
     // do windows feature
   },


### PR DESCRIPTION
If I’m not mistaken, the ignore flag should be reversed.

If `Deno.build.os === 'windows'`, the bench should run, not be ignored.