### PR TITLE
fix: include shebang example in toc.json

### DIFF
--- a/toc.json
+++ b/toc.json
@@ -99,7 +99,8 @@
       "subprocess": "Creating a subprocess",
       "os_signals": "OS signals",
       "file_system_events": "File system events",
-      "module_metadata": "Module metadata"
+      "module_metadata": "Module metadata",
+      "shebang": "Shebang"
     }
   },
   "testing": {


### PR DESCRIPTION
This example was added in https://github.com/denoland/manual/pull/347 but it was not added to the TOC, so it does not show up in the Examples section in the sidebar on https://deno.land/manual.