### PR TITLE
Add Fig as an autocomplete method

### DIFF
--- a/getting_started/command_line_interface.md
+++ b/getting_started/command_line_interface.md
@@ -189,3 +189,13 @@ More flags which affect the execution environment.
 --seed <NUMBER>              Seed Math.random()
 --v8-flags=<v8-flags>        Set V8 command line options. For help: ...
 ```
+
+## Autocomplete
+
+You can get IDE-style autocompletions for Deno with [Fig](https://fig.io/) <a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a>. It works in bash, zsh, and fish.
+
+To install, run:
+
+```shell
+brew install fig
+```

--- a/getting_started/command_line_interface.md
+++ b/getting_started/command_line_interface.md
@@ -192,7 +192,9 @@ More flags which affect the execution environment.
 
 ## Autocomplete
 
-You can get IDE-style autocompletions for Deno with [Fig](https://fig.io/) <a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a>. It works in bash, zsh, and fish.
+You can get IDE-style autocompletions for Deno with [Fig](https://fig.io/)
+<a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a>.
+It works in bash, zsh, and fish.
 
 To install, run:
 


### PR DESCRIPTION
[Fig](https://fig.io) provides autocomplete for 300+ CLI tools including Deno. It looks like this:

<img width="381" alt="image" src="https://user-images.githubusercontent.com/4949076/181374238-4d4c52b6-f258-4703-9708-4df715ac927d.png">

We think this will help users become more efficient with Deno CLI, so we would love to have Fig listed as an autocomplete method in your docs. Thanks so much and please let me know if you have any questions!