### PR TITLE
Fix some broken manual links in the introduction

### DIFF
--- a/introduction.md
+++ b/introduction.md
@@ -16,14 +16,14 @@ It's built on V8, Rust, and Tokio.
 - Supports [TypeScript](./typescript.md) out of the box.
 - Ships a single executable (`deno`).
 - Provides built-in [development tooling](./tools.md) like a code formatter
-  ([`deno fmt`](./tools/formatter.md)), a linter
-  ([`deno lint`](./tools/linter.md)), a test runner
-  ([`deno test`](./testing.md)), and a
+  ([`deno fmt`](./manual/tools/formatter)), a linter
+  ([`deno lint`](.manual/tools/linter)), a test runner
+  ([`deno test`](./manual/testing)), and a
   [language server for your editor](./getting_started/setup_your_environment.md#using-an-editoride).
 - Has [a set of reviewed (audited) standard modules](https://deno.land/std/)
   that are guaranteed to work with Deno.
 - Can [bundle](./tools/bundler.md) scripts into a single JavaScript file or
-  [executable](./tools/compiler.md).
+  [executable](./manual/tools/compiler).
 
 ## Philosophy
 

--- a/introduction.md
+++ b/introduction.md
@@ -17,7 +17,7 @@ It's built on V8, Rust, and Tokio.
 - Ships a single executable (`deno`).
 - Provides built-in [development tooling](./tools.md) like a code formatter
   ([`deno fmt`](./manual/tools/formatter)), a linter
-  ([`deno lint`](.manual/tools/linter)), a test runner
+  ([`deno lint`](./manual/tools/linter)), a test runner
   ([`deno test`](./manual/testing)), and a
   [language server for your editor](./getting_started/setup_your_environment.md#using-an-editoride).
 - Has [a set of reviewed (audited) standard modules](https://deno.land/std/)


### PR DESCRIPTION
Bring back changes to fix broken manual changes including formatter, tester, linter and compiler.