### PR TITLE
docs(toc): expose the profiling page

### DIFF
--- a/toc.json
+++ b/toc.json
@@ -164,6 +164,7 @@
       "web_platform_tests": "Web platform tests",
       "style_guide": "Style guide",
       "architecture": "Architecture",
+      "profiling": "Profiling",
       "release_schedule": "Release schedule"
     }
   }


### PR DESCRIPTION
I did not find any information about the flame graph in the official documents(https://deno.land/manual).

I think it's necessary to expose the profiling page.
