### PR TITLE
docs: remove weird language suggestions from FFI page

### DIFF
--- a/runtime/ffi_api.md
+++ b/runtime/ffi_api.md
@@ -1,8 +1,8 @@
 # Foreign Function Interface API
 
 As of Deno 1.13 and later, the FFI (foreign function interface) API allows users
-to call libraries written in native languages that support the C ABIs (Rust,
-C/C++, C#, Zig, Nim, Kotlin, etc) using `Deno.dlopen`.
+to call libraries written in native languages that support the C ABIs (C/C++,
+Rust, Zig, etc.) using `Deno.dlopen`.
 
 ## Usage
 


### PR DESCRIPTION
C# and Kotlin are not great recommendations. While both may technically be capable of creating shared libraries, it's not really along the "happy path" for either one. Experimental, very early stages, etc.

Nim is probably a more reasonable suggestion, but is *very* niche, and I know its got some weird complexity around "it's kind of garbage collected" but also "it supports manual memory management".

I think trimming it down to C, C++, Rust, and Zig provides a good number of candidates that actually have well documented support for creating shared libraries and making use of the C ABI.