### PR TITLE
docs: Update document building_from_source

### DIFF
--- a/contributing/building_from_source.md
+++ b/contributing/building_from_source.md
@@ -108,5 +108,5 @@ cargo build -vv
 cargo clean && cargo build -vv
 
 # Run:
-./target/debug/deno run cli/tests/testdata/002_hello.ts
+./target/debug/deno run https://deno.land/std/examples/welcome.ts
 ```

--- a/contributing/building_from_source.md
+++ b/contributing/building_from_source.md
@@ -108,5 +108,5 @@ cargo build -vv
 cargo clean && cargo build -vv
 
 # Run:
-./target/debug/deno run https://deno.land/std/examples/welcome.ts
+./target/debug/deno run cli/tests/testdata/run/002_hello.ts
 ```


### PR DESCRIPTION
## WHY

There is no sample code to run after build.
I expected it to be a git submodule related issue, but apparently the file doesn't exist.
It would be good to change the sample code to check if it is executable

```sh
:) % ./target/debug/deno run cli/tests/testdata/002_hello.ts
error: Module not found "file:///Users/asan/lab/oss/deno/cli/tests/testdata/002_hello.ts".
```

## WHAT 

- I change sample code. `cli/tests/testdata/002_hello.ts` to `https://deno.land/std/examples/welcome.ts`
- Please let me know if there is anything else suitable.