### PR TITLE
chore: update setup_deno action version

### DIFF
--- a/continuous_integration.md
+++ b/continuous_integration.md
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: denoland/setup-deno@v1.1.0
+      - uses: denoland/setup-deno@v1.1.1
         with:
           deno-version: v1.x # Run with latest stable Deno.
 ```


### PR DESCRIPTION
This updates the Deno GitHub action in the CI chapter to 1.1.1, which uses a non-deprecated version of Node.