### PR TITLE
docs: remove unused port

### DIFF
--- a/getting_started/first_steps.md
+++ b/getting_started/first_steps.md
@@ -147,8 +147,6 @@ One of the most common usecases for Deno is building an HTTP Server.
 ```ts
 import { serve } from "https://deno.land/std@0.157.0/http/server.ts";
 
-const port = 8080;
-
 const handler = async (request: Request): Promise<Response> => {
   const resp = await fetch("https://api.github.com/users/denoland", {
     // The init object here has an headers object containing a


### PR DESCRIPTION
Removes setting `port` to `8080` since it's not actually used. It's a bit confusing especially since it's different from the default value of `8000`.

Alternatively, the `port` can be used like `serve(handler, { port });`. In this case the other mentions of port `8000` should be updated as well. Let me know if this is preferable and I can try to add a commit for it.