### PR TITLE
fix(typo): Fix typo in `how_to_with_npm/prisma`

### DIFF
--- a/node/how_to_with_npm/prisma.md
+++ b/node/how_to_with_npm/prisma.md
@@ -66,7 +66,7 @@ deno run -A npm:prisma@^4.5 db push
 After that's complete, we'll need to generate a Prisma client for Data Proxy:
 
 ```shell, ignore
-deno run -A npm:prisma@^4.5 generate --data-prxoxy
+deno run -A npm:prisma@^4.5 generate --data-proxy
 ```
 
 ## Setup Prisma Data Platform


### PR DESCRIPTION
Hi!

This PR fix a typo in how_to_with_npm/prisma.md`