### PR TITLE
fix link to Deno Standard APIs

### DIFF
--- a/references.md
+++ b/references.md
@@ -2,7 +2,7 @@
 
 This chapter contains links to reference manuals and sheets, including:
 
-- [Deno Standard APIs](https://deno.land/api@v$CLI_VERSION)
+- [Deno Standard APIs](https://deno.land/api@$CLI_VERSION)
 - [Standard Library](https://deno.land/std@$STD_VERSION?doc)
 - [Deno-native third party modules](https://deno.land/x)
 - [Full Guide to Using Visual Studio Code](./references/vscode_deno.md)


### PR DESCRIPTION
Removed redundant "v"