### PR TITLE
chore: fix broken links and move link checker workflow to schedule

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -2,7 +2,7 @@ name: check-links
 
 on:
   push:
-    branches: [main, schedule_link_checker]
+    branches: [main]
   schedule:
     - cron: '0 0 * * *' # every day at midnight
 

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,17 @@
+name: check-links
+
+on:
+  push:
+    branches: [main, schedule_link_checker]
+  schedule:
+    - cron: '0 0 * * *' # every day at midnight
+
+jobs:
+  broken-links:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check Markdown Links
+        uses:  ruzickap/action-my-markdown-link-checker@v1
+        with:
+          config_file: .github/.mlc_config.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,23 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: denoland/setup-deno@v1.1.1
-      - name: Check Format
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v1.0.0
+
+      - name: Format
         run: deno fmt --check
 
   type-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: denoland/setup-deno@v1.1.1
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v1.0.0
+
       - name: Type-check Deno manual
         run: deno test --doc --unstable --import-map=.github/import_map.json --no-check=remote

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,40 +4,21 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, rewrite]
+    branches: [main]
 
 jobs:
-  broken-links:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-    
-      - name: Check Markdown Links
-        uses: ruzickap/action-my-markdown-link-checker@v1
-        with:
-          config_file: .github/.mlc_config.json
-
   format:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Set up Deno
-        uses: denoland/setup-deno@v1.0.0
-
-      - name: Format
+      - uses: actions/checkout@v3
+      - uses: denoland/setup-deno@v1.1.1
+      - name: Check Format
         run: deno fmt --check
 
   type-check:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Set up Deno
-        uses: denoland/setup-deno@v1.0.0
-
+      - uses: actions/checkout@v3
+      - uses: denoland/setup-deno@v1.1.1
       - name: Type-check Deno manual
         run: deno test --doc --unstable --import-map=.github/import_map.json --no-check=remote

--- a/basics/standard_library.md
+++ b/basics/standard_library.md
@@ -69,7 +69,7 @@ deno run --allow-read --allow-write --unstable main.ts
 ```
 
 To make sure that API producing error is unstable check
-[`lib.deno.unstable.d.ts`](https://github.com/denoland/deno/blob/$CLI_VERSION/cli/dts/lib.deno.unstable.d.ts)
+[`lib.deno.unstable.d.ts`](https://github.com/denoland/deno/blob/$CLI_VERSION/cli/tsc/dts/lib.deno.unstable.d.ts)
 declaration.
 
 This problem should be fixed in the near future. Feel free to omit the flag if

--- a/getting_started/command_line_interface.md
+++ b/getting_started/command_line_interface.md
@@ -161,15 +161,15 @@ reported. (To turn on type-checking for all modules, use `--check=all`.)
 
 | Subcommand     | Type checking mode |
 | -------------- | ------------------ |
-| `deno bench`   | 📁 Local            |
-| `deno bundle`  | 📁 Local            |
-| `deno cache`   | ❌ None             |
-| `deno check`   | 📁 Local            |
-| `deno compile` | 📁 Local            |
-| `deno eval`    | ❌ None             |
-| `deno repl`    | ❌ None             |
-| `deno run`     | ❌ None             |
-| `deno test`    | 📁 Local            |
+| `deno bench`   | 📁 Local           |
+| `deno bundle`  | 📁 Local           |
+| `deno cache`   | ❌ None            |
+| `deno check`   | 📁 Local           |
+| `deno compile` | 📁 Local           |
+| `deno eval`    | ❌ None            |
+| `deno repl`    | ❌ None            |
+| `deno run`     | ❌ None            |
+| `deno test`    | 📁 Local           |
 
 ### Permission flags
 

--- a/runtime.md
+++ b/runtime.md
@@ -22,5 +22,5 @@ For more details, view the chapter on
 [Built-in APIs](./runtime/builtin_apis.md).
 
 The TypeScript definitions for the Deno namespaces can be found in the
-[`lib.deno.ns.d.ts`](https://github.com/denoland/deno/blob/$CLI_VERSION/cli/dts/lib.deno.ns.d.ts)
+[`lib.deno.ns.d.ts`](https://github.com/denoland/deno/blob/$CLI_VERSION/cli/tsc/dts/lib.deno.ns.d.ts)
 file.

--- a/runtime/stability.md
+++ b/runtime/stability.md
@@ -15,7 +15,7 @@ Passing this flag does a few things:
 
 - It enables the use of unstable APIs during runtime.
 - It adds the
-  [`lib.deno.unstable.d.ts`](https://raw.githubusercontent.com/denoland/deno/main/cli/tsc/dts/lib.deno.unstable.d.ts)
+  [`lib.deno.unstable.d.ts`](https://doc.deno.land/https://raw.githubusercontent.com/denoland/deno/main/cli/tsc/dts/lib.deno.unstable.d.ts)
   file to the list of TypeScript definitions that are used for type checking.
   This includes the output of `deno types`.
 

--- a/runtime/stability.md
+++ b/runtime/stability.md
@@ -15,7 +15,7 @@ Passing this flag does a few things:
 
 - It enables the use of unstable APIs during runtime.
 - It adds the
-  [`lib.deno.unstable.d.ts`](https://doc.deno.land/https://raw.githubusercontent.com/denoland/deno/main/cli/dts/lib.deno.unstable.d.ts)
+  [`lib.deno.unstable.d.ts`](https://raw.githubusercontent.com/denoland/deno/main/cli/tsc/dts/lib.deno.unstable.d.ts)
   file to the list of TypeScript definitions that are used for type checking.
   This includes the output of `deno types`.
 


### PR DESCRIPTION
The link checker has been failing in a number of PRs lately. I found one link was actually broken because it was moved within denoland/deno, while other links are a bit flaky: broken in CI but available when visited in a browser. Therefore, as a suggestion I have moved the link checker to a separate workflow that runs on a schedule daily. This way it does not get in the way of PRs.

Edit: also fixes #480