### PR TITLE
chore: update Atom paragraph

### DIFF
--- a/getting_started/command_line_interface.md
+++ b/getting_started/command_line_interface.md
@@ -161,15 +161,15 @@ reported. (To turn on type-checking for all modules, use `--check=all`.)
 
 | Subcommand     | Type checking mode |
 | -------------- | ------------------ |
-| `deno bench`   | 📁 Local            |
-| `deno bundle`  | 📁 Local            |
-| `deno cache`   | ❌ None             |
-| `deno check`   | 📁 Local            |
-| `deno compile` | 📁 Local            |
-| `deno eval`    | ❌ None             |
-| `deno repl`    | ❌ None             |
-| `deno run`     | ❌ None             |
-| `deno test`    | 📁 Local            |
+| `deno bench`   | 📁 Local           |
+| `deno bundle`  | 📁 Local           |
+| `deno cache`   | ❌ None            |
+| `deno check`   | 📁 Local           |
+| `deno compile` | 📁 Local           |
+| `deno eval`    | ❌ None            |
+| `deno repl`    | ❌ None            |
+| `deno run`     | ❌ None            |
+| `deno test`    | 📁 Local           |
 
 ### Permission flags
 

--- a/getting_started/setup_your_environment.md
+++ b/getting_started/setup_your_environment.md
@@ -146,13 +146,14 @@ An example configuration for Deno via eglot:
     :lint t))
 ```
 
-### Atom
+### Pulsar
 
-The [Atom editor](https://atom.io) supports integrating with the Deno language
-server via the [atom-ide-deno](https://atom.io/packages/atom-ide-deno) package.
+The [Pulsar editor, formerly known as Atom](https://pulsar-edit.dev/) supports
+integrating with the Deno language server via the
+[atom-ide-deno](https://web.pulsar-edit.dev/packages/atom-ide-deno) package.
 `atom-ide-deno` requires that the Deno CLI be installed and the
-[atom-ide-base](https://atom.io/packages/atom-ide-base) package to be installed
-as well.
+[atom-ide-base](https://web.pulsar-edit.dev/packages/atom-ide-base) package to
+be installed as well.
 
 ### Sublime Text
 


### PR DESCRIPTION
Fixes #456. Atom will continue under the name Pulsar, some links to the Atom website also needed fixing.