### PR TITLE
Add `NPM_CONFIG_REGISTRY` to environment docs

### DIFF
--- a/getting_started/setup_your_environment.md
+++ b/getting_started/setup_your_environment.md
@@ -400,4 +400,5 @@ There are several environment variables which can impact the behavior of Deno:
 - `NO_PROXY` - Indicates hosts which should bypass the proxy set in the other
   environment variables. See the [Proxies](../basics/modules/proxies.md) section
   for more information.
-- `NPM_CONFIG_REGISTRY` - The npm registry to use when loading modules via [npm specifiers](../node/npm_specifiers.md)
+- `NPM_CONFIG_REGISTRY` - The npm registry to use when loading modules via
+  [npm specifiers](../node/npm_specifiers.md)

--- a/getting_started/setup_your_environment.md
+++ b/getting_started/setup_your_environment.md
@@ -400,4 +400,4 @@ There are several environment variables which can impact the behavior of Deno:
 - `NO_PROXY` - Indicates hosts which should bypass the proxy set in the other
   environment variables. See the [Proxies](../basics/modules/proxies.md) section
   for more information.
-- `DENO_NPM_REGISTRY` - The npm registry to use when loading modules via [npm specifiers](../node/npm_specifiers.md)
+- `NPM_CONFIG_REGISTRY` - The npm registry to use when loading modules via [npm specifiers](../node/npm_specifiers.md)

--- a/getting_started/setup_your_environment.md
+++ b/getting_started/setup_your_environment.md
@@ -400,3 +400,4 @@ There are several environment variables which can impact the behavior of Deno:
 - `NO_PROXY` - Indicates hosts which should bypass the proxy set in the other
   environment variables. See the [Proxies](../basics/modules/proxies.md) section
   for more information.
+- `DENO_NPM_REGISTRY` - The npm registry to use when loading modules via [npm specifiers](../node/npm_specifiers.md)


### PR DESCRIPTION
Related to: https://github.com/denoland/deno/issues/16105

I think there is probably more work to do to flesh out support for private registries (e.g would be great to formalize things like [auth configuration](https://docs.npmjs.com/cli/v9/configuring-npm/npmrc#auth-related-configuration)) but this at least documents a way to start integrating with a private registry.