### PR TITLE
chore: update link check settings

### DIFF
--- a/.github/.mlc_config.json
+++ b/.github/.mlc_config.json
@@ -12,7 +12,12 @@
     },
     {
       "pattern": [
-        "https://deno.land/images/schematic_v0.2.png"
+        "^https://deno.land/images/schematic_v0.2.png"
+      ]
+    },
+    {
+      "pattern": [
+        "^https://kinsta.com/signup/"
       ]
     },
     {

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -2,16 +2,17 @@ name: check-links
 
 on:
   push:
-    branches: [main]
+    branches: main
+  pull_request:
+    branches: main
   schedule:
     - cron: '0 0 * * *' # every day at midnight
-
 jobs:
   broken-links:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Check Markdown Links
-        uses:  ruzickap/action-my-markdown-link-checker@v1
+        uses: ruzickap/action-my-markdown-link-checker@v1
         with:
           config_file: .github/.mlc_config.json


### PR DESCRIPTION
This page (https://kinsta.com/signup/) returns 403 to bot access, and we can't check it in `check-links` CI. This PR updates the ignore settings to avoid the error.