### PR TITLE
Add `.ts` info to hashbang.md

### DIFF
--- a/examples/hashbang.md
+++ b/examples/hashbang.md
@@ -51,6 +51,8 @@ Start the script by calling it like any other command:
 
 - `-S` splits the command into arguments.
 
+- End the file name in `.ts` for the script to be interpreted as TypeScript.
+
 <!----------------------------------------------------------------------------->
 
 [Deno.env]: /api?s=Deno.env

--- a/examples/hashbang.md
+++ b/examples/hashbang.md
@@ -53,6 +53,8 @@ Start the script by calling it like any other command:
 
 - End the file name in `.ts` for the script to be interpreted as TypeScript.
 
+- Future plans include supporting the command-line option `--ext <type>`, relieving this naming restriction. See [denoland/deno#5088](https://github.com/denoland/deno/issues/5088).
+
 <!----------------------------------------------------------------------------->
 
 [Deno.env]: /api?s=Deno.env

--- a/examples/hashbang.md
+++ b/examples/hashbang.md
@@ -53,7 +53,9 @@ Start the script by calling it like any other command:
 
 - End the file name in `.ts` for the script to be interpreted as TypeScript.
 
-- Future plans include supporting the command-line option `--ext <type>`, relieving this naming restriction. See [denoland/deno#5088](https://github.com/denoland/deno/issues/5088).
+- Future plans include supporting the command-line option `--ext <type>`,
+  relieving this naming restriction. See
+  [denoland/deno#5088](https://github.com/denoland/deno/issues/5088).
 
 <!----------------------------------------------------------------------------->
 


### PR DESCRIPTION
Add a note in the help for creating a hashbang file, aka shebang file, to end the name of the file with the `.ts` when the file's source is TypeScript. The deno cli uses the file name extension for deciding TypeScript over JavaScript.

Future plans include supporting the command-line option `--ext <type>`, relieving this naming restriction. See [denoland/deno#5088](https://github.com/denoland/deno/issues/5088).