### PR TITLE
a bit more of an accurate example of file .js and .ts file extensions…

### DIFF
--- a/references/cheatsheet.md
+++ b/references/cheatsheet.md
@@ -2,7 +2,8 @@
 
 | Node.js                                | Deno                                           |
 | -------------------------------------- | ---------------------------------------------- |
-| `node file.js`                         | `deno run file.ts`                             |
+| `node file.js`                         | `deno run file.js`                             |
+| `ts-node file.ts`                      | `deno run file.ts`                             |
 | `npm i -g`                             | `deno install`                                 |
 | `npm i` / `npm install`                | _n/a_ ¹                                        |
 | `npm run`                              | `deno task`                                    |


### PR DESCRIPTION
… when comparing running node and deno. 'node' should only run .js files, 'ts-node' should be used to run .ts files. 
This better highlights the capabilities of deno to new users, showing that it can run both .js and .ts files out of the box. 