### PR TITLE
fix: lint's `--rules-exclude` now has higher precedence over `--rules-include`

### DIFF
--- a/tools/linter.md
+++ b/tools/linter.md
@@ -92,7 +92,8 @@ CLI flags:
   tags and will only use rules from `include`. Defaults to "recommended".
 
 - `--rules-exclude` - List of rule names that will be excluded from configured
-  tag sets. If the same rule is in `include` it will be run.
+  tag sets. Even if the same rule is in `include` it will be excluded; in other
+  words, `--rules-exclude` has higher precedence over `--rules-include`.
 
-- `--rules-include` - List of rule names that will be run. Even if the same rule
-  is in `exclude` it will be run.
+- `--rules-include` - List of rule names that will be run. If the same rule is
+  in `exclude` it will be excluded.


### PR DESCRIPTION
Updating deno_lint to the version including https://github.com/denoland/deno_lint/pull/1104 has a small change in its behavior. This commit updates the documentation regarding this change.

ref: https://github.com/denoland/deno/issues/17161