### PR TITLE
Use Web Stream APIs on examples

### DIFF
--- a/examples/fetch_data.md
+++ b/examples/fetch_data.md
@@ -54,9 +54,12 @@ try {
 ## Files and Streams
 
 Like in browsers, sending and receiving large files is possible thanks to the
-[Streams API](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API). The
-standard library's [streams module](https://deno.land/std@$STD_VERSION/streams/)
-can be used to convert a Deno file into a writable or readable stream.
+[Streams API](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API).
+[`Deno.FsFile`](https://deno.land/api@$CLI_VERSION?s=Deno.FsFile) API provides
+two properties:
+[`readable`](https://deno.land/api@$CLI_VERSION?s=Deno.FsFile#prop_readable) and
+[`writable`](https://deno.land/api@$CLI_VERSION?s=Deno.FsFile#prop_writable),
+which can be used to convert a Deno file into a writable or readable stream.
 
 **Command:** `deno run --allow-read --allow-write --allow-net fetch_file.ts`
 

--- a/examples/tcp_echo.md
+++ b/examples/tcp_echo.md
@@ -3,8 +3,9 @@
 ## Concepts
 
 - Listening for TCP port connections with [Deno.listen](/api?s=Deno.listen).
-- Use [copy](https://deno.land/std@$STD_VERSION/streams/conversion.ts?s=copy) to
-  take inbound data and redirect it to be outbound data.
+- Use [Deno.Conn.readable](/api?s=Deno.Conn#prop_readable) and
+  [Deno.Conn.writable](/api?s=Deno.Conn#prop_writable) to take inbound data and
+  redirect it to be outbound data.
 
 ## Example
 
@@ -15,11 +16,10 @@ returns to the client anything it sends.
 /**
  * echo_server.ts
  */
-import { copy } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
 const listener = Deno.listen({ port: 8080 });
 console.log("listening on 0.0.0.0:8080");
 for await (const conn of listener) {
-  copy(conn, conn).finally(() => conn.close());
+  conn.readable.pipeTo(conn.writable);
 }
 ```
 
@@ -40,6 +40,6 @@ hello world
 hello world
 ```
 
-Like the [cat.ts example](./unix_cat.md), the `copy()` function here also does
+Like the [cat.ts example](./unix_cat.md), the `pipeTo()` method here also does
 not make unnecessary memory copies. It receives a packet from the kernel and
 sends back, without further complexity.

--- a/examples/tcp_server.md
+++ b/examples/tcp_server.md
@@ -4,13 +4,12 @@ This is an example of a server which accepts connections on port 8080, and
 returns to the client anything it sends.
 
 ```ts
-import { copy } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
 const hostname = "0.0.0.0";
 const port = 8080;
 const listener = Deno.listen({ hostname, port });
 console.log(`Listening on ${hostname}:${port}`);
 for await (const conn of listener) {
-  copy(conn, conn);
+  conn.readable.pipeTo(conn.writable);
 }
 ```
 
@@ -35,6 +34,6 @@ hello world
 hello world
 ```
 
-Like the `cat.ts` example, the `copy()` function here also does not make
-unnecessary memory copies. It receives a packet from the kernel and sends it
-back, without further complexity.
+Like the `cat.ts` example, the `pipeTo(writable)` method does not make a copy of
+the data. The data is directly written from the readable stream to the writable
+stream.

--- a/examples/unix_cat.md
+++ b/examples/unix_cat.md
@@ -5,9 +5,11 @@
 - Use the Deno runtime API to output the contents of a file to the console.
 - [Deno.args](/api?s=Deno.args) accesses the command line arguments.
 - [Deno.open](/api?s=Deno.open) is used to get a handle to a file.
-- [copy](https://deno.land/std@$STD_VERSION/streams/conversion.ts?s=copy) is
-  used to transfer data from the file to the output stream.
-- Files should be closed when you are finished with them
+- [Deno.stdout.writable](/api?s=Deno.stdout.writable) is used to get a writable
+  stream to the console standard output.
+- [Deno.FsFile.readable](/api?s=Deno.FsFile#prop_readable) is used to get a
+  readable stream from the file. (This readable stream closes the file when it
+  is finished reading, so it is not necessary to close the file explicitly.)
 - Modules can be run directly from remote URLs.
 
 ## Example
@@ -19,11 +21,9 @@ is opened, and printed to stdout (e.g. the console).
 /**
  * cat.ts
  */
-import { copy } from "https://deno.land/std@$STD_VERSION/streams/copy.ts";
 for (const filename of Deno.args) {
   const file = await Deno.open(filename);
-  await copy(file, Deno.stdout);
-  file.close();
+  await file.readable.pipeTo(Deno.stdout.writable);
 }
 ```
 

--- a/getting_started/first_steps.md
+++ b/getting_started/first_steps.md
@@ -112,19 +112,17 @@ In this program each command-line argument is assumed to be a filename, the file
 is opened, and printed to stdout.
 
 ```ts
-import { copy } from "https://deno.land/std@$STD_VERSION/streams/conversion.ts";
 const filenames = Deno.args;
 for (const filename of filenames) {
   const file = await Deno.open(filename);
-  await copy(file, Deno.stdout);
-  file.close();
+  await file.readable.pipeTo(Deno.stdout.writable);
 }
 ```
 
-The `copy()` function here actually makes no more than the necessary
-kernel→userspace→kernel copies. That is, the same memory from which data is read
-from the file, is written to stdout. This illustrates a general design goal for
-I/O streams in Deno.
+The `ReadableStream.pipeTo(writable)` method here actually makes no more than
+the necessary kernel→userspace→kernel copies. That is, the same memory from
+which data is read from the file, is written to stdout. This illustrates a
+general design goal for I/O streams in Deno.
 
 Again, here, we need to give --allow-read access to the program.
 


### PR DESCRIPTION
Replace usages of `https://deno.land/std@$STD_VERSION/streams/conversion.ts` wherever possible.