### PR TITLE
Fix an invalid command line option

### DIFF
--- a/node/npm_specifiers.md
+++ b/node/npm_specifiers.md
@@ -47,7 +47,7 @@ console.log("listening on http://localhost:3000/");
 Then doing the following will start a simple express server:
 
 ```sh
-$ deno run --A main.ts
+$ deno run -A main.ts
 listening on http://localhost:3000/
 ```
 


### PR DESCRIPTION
Fixed an invalid command line option `--A` in https://deno.land/manual@v1.29.1/node/npm_specifiers