### PR TITLE
docs: update std/dotenv usage

### DIFF
--- a/.github/.mlc_config.json
+++ b/.github/.mlc_config.json
@@ -34,6 +34,11 @@
       "pattern": [
         "^https://dash.cloudflare.com"
       ]
+    },
+    {
+      "pattern": [
+        "^https://web.pulsar-edit.dev/"
+      ]
     }
   ],
   "httpHeaders": [

--- a/basics/env_variables.md
+++ b/basics/env_variables.md
@@ -28,15 +28,14 @@ Let's say you have an `.env` file that looks like this:
 PASSWORD=Geheimnis
 ```
 
-To access the environment variables in the `.env` file, import the config
-function from the standard library. Then, import the configuration using the
-`config` function.
+To access the environment variables in the `.env` file, import the `load`
+function from the standard library. Then, import the configuration using it.
 
 ```ts
-import { config } from "https://deno.land/x/dotenv/mod.ts";
+import { load } from "https://deno.land/std/dotenv/mod.ts";
 
-const configData = await config();
-const password = configData["PASSWORD"];
+const env = await load();
+const password = env["PASSWORD"];
 
 console.log(password);
 // "Geheimnis"

--- a/basics/env_variables.md
+++ b/basics/env_variables.md
@@ -33,7 +33,7 @@ function from the standard library. Then, import the configuration using the
 `config` function.
 
 ```ts
-import { config } from "https://deno.land/std/dotenv/mod.ts";
+import { config } from "https://deno.land/x/dotenv/mod.ts";
 
 const configData = await config();
 const password = configData["PASSWORD"];


### PR DESCRIPTION
This PR updates the usage of `std/dotenv` module. ref: https://github.com/denoland/deno_std/pull/3134

also ignores `https://web.pulsar-edit.dev/` in link checks in CI as the pages under that domain now return 505 error responses.