### PR TITLE
Fix DenoDB spelling

### DIFF
--- a/basics/connecting_to_databases.md
+++ b/basics/connecting_to_databases.md
@@ -187,7 +187,7 @@ Deno supports multiple ORMs, including Prisma and DenoDB.
 
 ### DenoDB
 
-[Denodb](https://deno.land/x/denodb) is a Deno-specific ORM.
+[DenoDB](https://deno.land/x/denodb) is a Deno-specific ORM.
 
 #### Connect to DenoDB
 


### PR DESCRIPTION
This fixes the capitalization of `DenoDB` to match the other spellings.