### PR TITLE
docs: Add explicit non-goals section

### DIFF
--- a/introduction.md
+++ b/introduction.md
@@ -56,6 +56,10 @@ have been historically written with Bash or Python.
 - Keep V8 concepts out of user land.
 - Serve HTTP efficiently.
 
+## Explicit Non-Goals
+
+- (Things Deno specifically will not do...)
+
 ## Other key behaviors
 
 - Fetch and cache remote code upon first execution, and never update it until


### PR DESCRIPTION
Consider adding a section explaining what Deno does **not** aim to do.