### PR TITLE
Remove cjs and cts from test/bench glob documentation

### DIFF
--- a/basics/testing.md
+++ b/basics/testing.md
@@ -238,14 +238,14 @@ Notes:
 To run the test, call `deno test` with the file that contains your test
 function. You can also omit the file name, in which case all tests in the
 current directory (recursively) that match the glob
-`{*_,*.,}test.{ts, tsx, mts, js, mjs, jsx, cjs, cts}` will be run. If you pass a
+`{*_,*.,}test.{ts, tsx, mts, js, mjs, jsx}` will be run. If you pass a
 directory, all files in the directory that match this glob will be run.
 
 The glob expands to:
 
-- files named `test.{ts, tsx, mts, js, mjs, jsx, cjs, cts}`,
-- or files ending with `.test.{ts, tsx, mts, js, mjs, jsx, cjs, cts}`,
-- or files ending with `_test.{ts, tsx, mts, js, mjs, jsx, cjs, cts}`
+- files named `test.{ts, tsx, mts, js, mjs, jsx}`,
+- or files ending with `.test.{ts, tsx, mts, js, mjs, jsx}`,
+- or files ending with `_test.{ts, tsx, mts, js, mjs, jsx}`
 
 ```shell
 # Run all tests in the current directory and all sub-directories

--- a/tools/benchmarker.md
+++ b/tools/benchmarker.md
@@ -137,8 +137,8 @@ You can specify multiple groups in the same file.
 To run a benchmark, call `deno bench` with the file that contains your bench
 function. You can also omit the file name, in which case all benchmarks in the
 current directory (recursively) that match the glob
-`{*_,*.,}bench.{ts, tsx, mts, js, mjs, jsx}` will be run. If you pass
-a directory, all files in the directory that match this glob will be run.
+`{*_,*.,}bench.{ts, tsx, mts, js, mjs, jsx}` will be run. If you pass a
+directory, all files in the directory that match this glob will be run.
 
 The glob expands to:
 

--- a/tools/benchmarker.md
+++ b/tools/benchmarker.md
@@ -137,14 +137,14 @@ You can specify multiple groups in the same file.
 To run a benchmark, call `deno bench` with the file that contains your bench
 function. You can also omit the file name, in which case all benchmarks in the
 current directory (recursively) that match the glob
-`{*_,*.,}bench.{ts, tsx, mts, js, mjs, jsx, cjs, cts}` will be run. If you pass
+`{*_,*.,}bench.{ts, tsx, mts, js, mjs, jsx}` will be run. If you pass
 a directory, all files in the directory that match this glob will be run.
 
 The glob expands to:
 
-- files named `bench.{ts, tsx, mts, js, mjs, jsx, cjs, cts}`,
-- or files ending with `.bench.{ts, tsx, mts, js, mjs, jsx, cjs, cts}`,
-- or files ending with `_bench.{ts, tsx, mts, js, mjs, jsx, cjs, cts}`
+- files named `bench.{ts, tsx, mts, js, mjs, jsx}`,
+- or files ending with `.bench.{ts, tsx, mts, js, mjs, jsx}`,
+- or files ending with `_bench.{ts, tsx, mts, js, mjs, jsx}`
 
 ```shell
 # Run all benches in the current directory and all sub-directories


### PR DESCRIPTION
Although it's true that deno test/bench will find these files, it doesn't really make sense that it does. We should remove this from the documentation in order to not encourage it and consider deprecating this in the future.