### PR TITLE
Docs: hashbang.md: Don't use sudo for chmod

### DIFF
--- a/examples/hashbang.md
+++ b/examples/hashbang.md
@@ -36,7 +36,7 @@ You may require to give the script execution permissions.
 #### Linux
 
 ```shell
-sudo chmod +x hashbang.ts
+chmod +x hashbang.ts
 ```
 
 ### Execute


### PR DESCRIPTION
Presumably the user owns the script file in question, so there's no earthy reason why they should need to run `chmod` with root permissions.