### PR TITLE
file_server: fix bug after file miss

### DIFF
--- a/examples/file_server.md
+++ b/examples/file_server.md
@@ -42,7 +42,7 @@ async function handleHttp(conn: Deno.Conn) {
       // If the file cannot be opened, return a "404 Not Found" response
       const notFoundResponse = new Response("404 Not Found", { status: 404 });
       await requestEvent.respondWith(notFoundResponse);
-      return;
+      continue;
     }
 
     // Build a readable stream so the file doesn't have to be fully loaded into


### PR DESCRIPTION
In the current example, 1 file miss causes the fileserver to break.

Because `return` is used, the code breaks out of the function, causing subsequent requests to fail.

By changing this to `continue`, the code continues to work as expected.