### PR TITLE
chore: update contributing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
 # Deno Manual
 
-This repository is the official documentation for Deno.
-
-Manual is available at: https://deno.land/manual
+This repository is the official documentation for Deno, and it's available at:
+https://deno.land/manual
 
 ## Contributing
 
-Clone `dotland` project next to this manual project. The below commands start
-the local `deno.land` website with the local manual contents. You can preview
-how it's rendered.
+1. Clone this project and `dotland` in the same parent folder:
 
 ```
+git clone https://github.com/denoland/manual.git
 git clone https://github.com/denoland/dotland.git
+```
+
+2. Move into the `dotland` folder, and run the following command to start the
+   local `deno.land` website with the local manual contents:
+
+```
 cd dotland
 MANUAL_PATH=../manual deno task start
 ```

--- a/node/node_specifiers.md
+++ b/node/node_specifiers.md
@@ -28,4 +28,4 @@ anyway.
 Support for importing Node.js built-in modules is implemented in Deno std's
 Node.js compatibility layer. Documentation on which modules are implemented or
 not can be found in its repository:
-https://github.com/denoland/deno_std/tree/main/node#deno-nodejs-compatibility
+https://github.com/denoland/deno/blob/main/ext/node/polyfills/README.md


### PR DESCRIPTION
A very small update to the contributing section, to make it clearer the user has to clone both repositories to be able to run `manual`.

I also had to update this broken link: https://github.com/denoland/deno_std/tree/main/node#deno-nodejs-compatibility

It looks like it was moved here, but please let me know if that's wrong: https://github.com/denoland/deno/blob/main/ext/node/polyfills/README.md