### PR TITLE
fix(manual) adds deno_emit and rollup to the list of 'deno bundle' alt

### DIFF
--- a/tools/bundler.md
+++ b/tools/bundler.md
@@ -1,4 +1,4 @@
-# WARNING: `deno bundle` has been deprecated and will be removed in some future release. Use esbuild instead.
+# WARNING: `deno bundle` has been deprecated and will be removed in some future release. Use [deno_emit](https://github.com/denoland/deno_emit), [esbuild](https://esbuild.github.io/) or [rollup](https://rollupjs.org) instead.
 
 # Bundling
 


### PR DESCRIPTION
Currently the deprecation warning just suggests ESbuild as an alternative to `deno bundle`. `deno_emit` and Rollup are two other valid methods. 

This is also inline with the logged warning when calling `deno bundle` on latest (see: https://github.com/denoland/deno/blob/main/cli/tools/bundle.rs#L35)

Mostly helpful because `deno_emit` took me awhile to find but is exactly what I needed for a project I'm working on. 