### PR TITLE
Add structs to FFI manual

### DIFF
--- a/runtime/ffi_api.md
+++ b/runtime/ffi_api.md
@@ -215,23 +215,24 @@ handlers would only set a flag that can later be polled similarly to how
 
 Here's a list of types supported currently by the Deno FFI API.
 
-| FFI Type      | Deno                 | C                        | Rust                      |
-| ------------- | -------------------- | ------------------------ | ------------------------- |
-| `i8`          | `number`             | `char` / `signed char`   | `i8`                      |
-| `u8`          | `number`             | `unsigned char`          | `u8`                      |
-| `i16`         | `number`             | `short int`              | `i16`                     |
-| `u16`         | `number`             | `unsigned short int`     | `u16`                     |
-| `i32`         | `number`             | `int` / `signed int`     | `i32`                     |
-| `u32`         | `number`             | `unsigned int`           | `u32`                     |
-| `i64`         | `number \| bigint`   | `long long int`          | `i64`                     |
-| `u64`         | `number \| bigint`   | `unsigned long long int` | `u64`                     |
-| `usize`       | `number \| bigint`   | `size_t`                 | `usize`                   |
-| `f32`         | `number \| bigint`   | `float`                  | `f32`                     |
-| `f64`         | `number \| bigint`   | `double`                 | `f64`                     |
-| `void`[1]     | `undefined`          | `void`                   | `()`                      |
-| `pointer`     | `{} \| null`         | `void *`                 | `*mut c_void`             |
-| `buffer`[2]   | `TypedArray \| null` | `uint8_t *`              | `*mut u8`                 |
-| `function`[3] | `{} \| null`         | `void (*fun)()`          | `Option<extern "C" fn()>` |
+| FFI Type               | Deno                 | C                        | Rust                      |
+| ---------------------- | -------------------- | ------------------------ | ------------------------- |
+| `i8`                   | `number`             | `char` / `signed char`   | `i8`                      |
+| `u8`                   | `number`             | `unsigned char`          | `u8`                      |
+| `i16`                  | `number`             | `short int`              | `i16`                     |
+| `u16`                  | `number`             | `unsigned short int`     | `u16`                     |
+| `i32`                  | `number`             | `int` / `signed int`     | `i32`                     |
+| `u32`                  | `number`             | `unsigned int`           | `u32`                     |
+| `i64`                  | `number \| bigint`   | `long long int`          | `i64`                     |
+| `u64`                  | `number \| bigint`   | `unsigned long long int` | `u64`                     |
+| `usize`                | `number \| bigint`   | `size_t`                 | `usize`                   |
+| `f32`                  | `number \| bigint`   | `float`                  | `f32`                     |
+| `f64`                  | `number \| bigint`   | `double`                 | `f64`                     |
+| `void`[1]              | `undefined`          | `void`                   | `()`                      |
+| `pointer`              | `{} \| null`         | `void *`                 | `*mut c_void`             |
+| `buffer`[2]            | `TypedArray \| null` | `uint8_t *`              | `*mut u8`                 |
+| `function`[3]          | `{} \| null`         | `void (*fun)()`          | `Option<extern "C" fn()>` |
+| `{ struct: [...] }`[4] | `TypedArray`         | `struct MyStruct`        | `MyStruct`                |
 
 As of Deno 1.25, the `pointer` type has been split into a `pointer` and a
 `buffer` type to ensure users take advantage of optimizations for Typed Arrays,
@@ -243,6 +244,11 @@ opaque pointer object or `null` for null pointers.
   pointer object or `null` when used as result type like the `pointer` type.
 - [3] `function` type works exactly the same as the `pointer` type as a
   parameter and result type.
+- [4] `struct` type is for passing and returning C structs by value (copy). The
+  `struct` array must enumerate each of the struct's fields' type in order. The
+  structs are padded automatically: Packed structs can be defined by using an
+  appropriate amount of `u8` fields to avoid padding. Only TypedArrays are
+  supported as structs, and structs are always returned as `Uint8Array`s.
 
 ## deno_bindgen
 


### PR DESCRIPTION
We'd apparently forgotten to add this feature, even though it already came out in January.