### PR TITLE
feat: add algolia update ci

### DIFF
--- a/.github/workflows/update-algolia.yml
+++ b/.github/workflows/update-algolia.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   update-algolia:
     runs-on: ubuntu-latest
+    env:
+      ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+      ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/update-algolia.yml
+++ b/.github/workflows/update-algolia.yml
@@ -1,0 +1,19 @@
+name: main
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  update-algolia:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v1.0.0
+
+      - name: Update Algolia
+        working-directory: ./.tools
+        run: deno task update

--- a/.tools/deno.json
+++ b/.tools/deno.json
@@ -1,6 +1,6 @@
 {
   "importMap": "./import-map.json",
   "tasks": {
-    "build": "deno run --check --allow-read=.. --allow-env --allow-net main.ts"
+    "update": "deno run --check --allow-read=.. --allow-env --allow-net main.ts"
   }
 }

--- a/.tools/import-map.json
+++ b/.tools/import-map.json
@@ -1,7 +1,7 @@
 {
   "imports": {
-    "@algolia/requester-fetch": "https://esm.sh/@algolia/requester-fetch@4.14.2?pin=v90",
-    "algoliasearch": "https://esm.sh/algoliasearch@4.14.2?pin=v90",
+    "@algolia/requester-fetch": "https://esm.sh/@algolia/requester-fetch@4.14.3?pin=v90",
+    "algoliasearch": "https://esm.sh/algoliasearch@4.14.3?pin=v90",
     "dax": "https://deno.land/x/dax@0.11.0/mod.ts",
     "markdown_records": "https://deno.land/x/markdown_records@0.2.0/mod.ts",
     "std/": "https://deno.land/std@0.178.0/"

--- a/.tools/main.ts
+++ b/.tools/main.ts
@@ -3,16 +3,13 @@ import algoliasearch from "algoliasearch";
 import dax from "dax";
 import { MarkdownRecord, toRecords } from "markdown_records";
 import { load } from "std/dotenv/mod.ts";
+import toc from "../toc.json" assert { type: "json" };
 
-interface Section {
-  name: string;
-  children?: {
-    [child: string]: string;
-  };
-}
-
-interface TableOfContents {
-  [section: string]: Section;
+export interface TableOfContents {
+  [slug: string]: {
+    name: string;
+    children?: TableOfContents;
+  } | string;
 }
 
 const MANUAL_INDEX = "manual";
@@ -20,9 +17,6 @@ const MANUAL_INDEX = "manual";
 dax.logStep("Generate manual search records...");
 
 dax.logStep("Parsing manual toc...");
-
-const toc: TableOfContents =
-  (await import("../toc.json", { assert: { type: "json" } })).default;
 
 dax.logLight(`  ${Object.keys(toc).length} sections in toc.`);
 
@@ -81,41 +75,36 @@ function markdownToSearch(
 
 let searchRecords: SearchRecord[] = [];
 
-for (const [id, section] of Object.entries(toc)) {
-  let content: string;
-  try {
-    content = await Deno.readTextFile(`../${id}.md`);
-  } catch (err) {
-    dax.logError(`Error attempting to read "/${id}.md".`);
-    console.log(err);
-    continue;
-  }
-  const docPath = `/manual/${id}`;
-  const hierarchy = [section.name];
-  dax.logLight(`  generating "${docPath}"...`);
-  const records = (await toRecords(content))
-    .map((record, i) => markdownToSearch(hierarchy, docPath, record, i));
-  searchRecords = searchRecords.concat(records);
-  if (section.children) {
-    for (const [childId, child] of Object.entries(section.children)) {
-      let content: string;
-      try {
-        content = await Deno.readTextFile(`../${id}/${childId}.md`);
-      } catch (err) {
-        dax.logError(`Error attempting to read "/${id}/${childId}.md".`);
-        console.log(err);
-        continue;
-      }
-      const docPath = `/manual/${id}/${childId}`;
-      const hierarchy = [section.name, child];
-      dax.logLight(`  generating "${docPath}"...`);
-      const records = (await toRecords(content))
-        .map((record, i) => markdownToSearch(hierarchy, docPath, record, i));
-      searchRecords = searchRecords.concat(records);
+async function travelToC(
+  table: TableOfContents,
+  parents: [name: string, id: string][],
+) {
+  for (const [id, section] of Object.entries(table)) {
+    const name = typeof section === "string" ? section : section.name;
+    const fullHierachy: [string, string][] = [...parents, [name, id]];
+    let content: string;
+    const fullId = fullHierachy.map(([_, id]) => id).join("/");
+    try {
+      content = await Deno.readTextFile(`../${fullId}.md`);
+    } catch (err) {
+      dax.logError(`Error attempting to read "/${fullId}.md".`);
+      console.log(parents, id, section, err);
+      continue;
+    }
+    const docPath = `/manual/${id}`;
+    const nameHierarchy = fullHierachy.map(([name, _]) => name);
+    dax.logLight(`  generating "${docPath}"...`);
+    const records = (await toRecords(content))
+      .map((record, i) => markdownToSearch(nameHierarchy, docPath, record, i));
+    searchRecords = searchRecords.concat(records);
+
+    if (typeof section !== "string" && section.children) {
+      await travelToC(section.children, fullHierachy);
     }
   }
 }
 
+await travelToC(toc, []);
 dax.logStep(`Uploading ${searchRecords.length} search records to algolia...`);
 
 await load({ export: true });


### PR DESCRIPTION
This adds a ci that gets run whenever a tag is pushed, which updates the algolia search. follow up to #390.
also fixes the script to work with the latest verison of the manual
