### PR TITLE
Update example of net permission for workers

### DIFF
--- a/runtime/workers.md
+++ b/runtime/workers.md
@@ -165,7 +165,7 @@ the `deno.permissions` option in the worker API.
     deno: {
       permissions: {
         net: [
-          "https://deno.land/",
+          "deno.land",
         ],
         read: [
           new URL("./file_1.txt", import.meta.url),


### PR DESCRIPTION
Hi! I couldn't find a canonical place explaining this better or the actual implementation but by testing it locally it seems that when setting the `net` permissions for workers it only allow strings containing domains and not full URLs which is the current example in the worker documentation.

Reading this [issue](https://github.com/denoland/deno/issues/5242) it seems that it's just domain indeed.

Maybe the most canonical place explaining this format is [here](https://deno.land/manual@v1.32.3/basics/permissions#permissions-list)