### PR TITLE
docs: update compiler.md

### DIFF
--- a/tools/compiler.md
+++ b/tools/compiler.md
@@ -37,6 +37,4 @@ target.
 
 ## Unavailable in executables
 
-- [Workers](../runtime/workers.md)
-- Dynamic Imports
 - [Web Storage API](../runtime/web_storage_api.md)


### PR DESCRIPTION
deno v1.32 adds support for dynamic imports and web workers

https://deno.com/blog/v1.32#deno-compile-support-for-web-workers-and-dynamic-import