### PR TITLE
fix(typo): Fix typo in `manual/basics/react.md`

### DIFF
--- a/basics/react.md
+++ b/basics/react.md
@@ -6,7 +6,7 @@ below.
 If you want to better understand how JSX and Deno interface under the hood, read
 on [here](../advanced/jsx_dom).
 
-Note:: Fresh and Aleph.js provide a framework for developing React-like
+Note: Fresh and Aleph.js provide a framework for developing React-like
 websites, but use an alternative foundational technology, Preact to provide a
 better, more performant experience.
 

--- a/basics/react.md
+++ b/basics/react.md
@@ -6,9 +6,9 @@ below.
 If you want to better understand how JSX and Deno interface under the hood, read
 on [here](../advanced/jsx_dom).
 
-Note: Fresh and Aleph.js provide a framework for developing React-like
-websites, but use an alternative foundational technology, Preact to provide a
-better, more performant experience.
+Note: Fresh and Aleph.js provide a framework for developing React-like websites,
+but use an alternative foundational technology, Preact to provide a better, more
+performant experience.
 
 ## Fresh
 


### PR DESCRIPTION
Hi! This PR fix a typo in `manual/basics/react.md`. Instead of two colons, there should be one.