### PR TITLE
Fix scopes key in import map docs

### DIFF
--- a/basics/import_maps.md
+++ b/basics/import_maps.md
@@ -88,7 +88,7 @@ The other situation where import maps can be very useful is to override imports
 in specific modules.
 
 Let's say you want to override the deno_std import from 0.177.0 to the latest in
-all of your imported modules, but for the `https://deno.land/x/example` module
+all of your imported modules, but for the `https://deno.land/x/example/` module
 you want to use files in a local `patched` directory. You can do this by using a
 scope in the import map that looks something like this:
 
@@ -98,7 +98,7 @@ scope in the import map that looks something like this:
     "https://deno.land/std@0.177.0/": "https://deno.land/std@$STD_VERSION/"
   },
   "scopes": {
-    "https://deno.land/x/example": {
+    "https://deno.land/x/example/": {
       "https://deno.land/std@0.177.0/": "./patched/"
     }
   }


### PR DESCRIPTION
From my understanding, the trailing slash is significant.