### PR TITLE
Document install instruction using asdf

### DIFF
--- a/getting_started/installation.md
+++ b/getting_started/installation.md
@@ -53,6 +53,13 @@ Using [Nix](https://nixos.org/download.html) (macOS and Linux):
 nix-shell -p deno
 ```
 
+Using [asdf](https://asdf-vm.com/) (macOS and Linux):
+
+```shell
+asdf plugin-add deno https://github.com/asdf-community/asdf-deno.git
+asdf install deno latest
+```
+
 Build and install from source using [Cargo](https://crates.io/crates/deno):
 
 ```shell

--- a/getting_started/installation.md
+++ b/getting_started/installation.md
@@ -58,6 +58,12 @@ Using [asdf](https://asdf-vm.com/) (macOS and Linux):
 ```shell
 asdf plugin-add deno https://github.com/asdf-community/asdf-deno.git
 asdf install deno latest
+
+# To install globally
+asdf global deno latest
+
+# To install locally (current project only)
+asdf local deno latest
 ```
 
 Build and install from source using [Cargo](https://crates.io/crates/deno):


### PR DESCRIPTION
While I'm not too sure either to recommend it as the [default way](https://github.com/denoland/manual/issues/393) to install Deno as asdf is not cross-platform, listing it in the documentation is a start.

Let me know if you want me to adjust other sections of the documentation.