### PR TITLE
Add allowed values for allow-sys flag

### DIFF
--- a/basics/permissions.md
+++ b/basics/permissions.md
@@ -17,35 +17,39 @@ deno run --allow-read mod.ts
 
 The following permissions are available:
 
-- **--allow-env=\<allow-env\>** Allow environment access for things like getting
-  and setting of environment variables. Since Deno 1.9, you can specify an
-  optional, comma-separated list of environment variables to provide an
+- **--allow-env=\<VARIABLE_NAME\>** Allow environment access for things like
+  getting and setting of environment variables. Since Deno 1.9, you can specify
+  an optional, comma-separated list of environment variables to provide an
   allow-list of allowed environment variables.
-- **--allow-sys=\<allow-sys\>** Allow access to APIs that provide information
+- **--allow-sys=\<API_NAME\>** Allow access to APIs that provide information
   about user's operating system, eg. `Deno.osRelease()` and
-  `Deno.systemMemoryInfo()`.
+  `Deno.systemMemoryInfo()`. You can specify a comma-separated list of allowed
+  interfaces from the following list: `hostname`, `osRelease`, `osUptime`,
+  `loadavg`, `networkInterfaces`, `systemMemoryInfo`, `uid`, and `gid`. These
+  strings map to functions in the `Deno` namespace that provide OS info, like
+  [Deno.systemMemoryInfo](https://deno.land/api?s=Deno.SystemMemoryInfo).
 - **--allow-hrtime** Allow high-resolution time measurement. High-resolution
   time can be used in timing attacks and fingerprinting.
-- **--allow-net=\<allow-net\>** Allow network access. You can specify an
+- **--allow-net=\<IP/HOSTNAME\>** Allow network access. You can specify an
   optional, comma-separated list of IP addresses or hostnames (optionally with
   ports) to provide an allow-list of allowed network addresses.
-- **--allow-ffi=\<allow-ffi\>** Allow loading of dynamic libraries. You can
-  specify an optional, comma-separated list of directories or files to provide
-  an allow-list of allowed dynamic libraries to load. Be aware that dynamic
+- **--allow-ffi=\<PATH\>** Allow loading of dynamic libraries. You can specify
+  an optional, comma-separated list of directories or files to provide an
+  allow-list of allowed dynamic libraries to load. Be aware that dynamic
   libraries are not run in a sandbox and therefore do not have the same security
   restrictions as the Deno process. Therefore, use with caution. Please note
   that --allow-ffi is an unstable feature.
-- **--allow-read=\<allow-read\>** Allow file system read access. You can specify
-  an optional, comma-separated list of directories or files to provide an
+- **--allow-read=\<PATH\>** Allow file system read access. You can specify an
+  optional, comma-separated list of directories or files to provide an
   allow-list of allowed file system access.
-- **--allow-run=\<allow-run\>** Allow running subprocesses. Since Deno 1.9, You
-  can specify an optional, comma-separated list of subprocesses to provide an
-  allow-list of allowed subprocesses. Be aware that subprocesses are not run in
-  a sandbox and therefore do not have the same security restrictions as the Deno
-  process. Therefore, use with caution.
-- **--allow-write=\<allow-write\>** Allow file system write access. You can
-  specify an optional, comma-separated list of directories or files to provide
-  an allow-list of allowed file system access.
+- **--allow-run=\<PROGRAM_NAME\>** Allow running subprocesses. Since Deno 1.9,
+  You can specify an optional, comma-separated list of subprocesses to provide
+  an allow-list of allowed subprocesses. Be aware that subprocesses are not run
+  in a sandbox and therefore do not have the same security restrictions as the
+  Deno process. Therefore, use with caution.
+- **--allow-write=\<PATH\>** Allow file system write access. You can specify an
+  optional, comma-separated list of directories or files to provide an
+  allow-list of allowed file system access.
 - **-A, --allow-all** Allow all permissions. This enables all security sensitive
   functions. Use with caution.
 


### PR DESCRIPTION
While [updating the help text](https://github.com/denoland/deno/issues/18685) for the `--allow-sys` flag in the CLI, I noticed that it wasn't clear which APIs could be allowed when using this option. [This appears to be the list](https://github.com/denoland/deno/blob/main/runtime/permissions/mod.rs#L320) - I added this enumeration of function names to the docs here!

Preview:
![image](https://user-images.githubusercontent.com/29193/234008943-ee4c80dd-80d5-4a33-822f-920f4825df23.png)
