### PR TITLE
docs(style_guide): update standard library style guide

### DIFF
--- a/references/contributing/style_guide.md
+++ b/references/contributing/style_guide.md
@@ -397,9 +397,60 @@ class MyClass {
 
 #### Naming convention
 
-Always use camel or pascal case. Some Web APIs use uppercase acronyms (`JSON`,
-`URL`, `URL.createObjectURL()` etc.). Deno does not follow this convention and
-also uses camel or pascal case.
+Use `camelCase` for functions. Use `PascalCase` for classes, types, interfaces,
+and enums. Use `UPPER_SNAKE_CASE` for static items, such as `string`, `number`,
+`bigint`, `boolean`, `RegExp`, arrays of static items, records of static keys
+and values, etc.
+
+Good:
+
+```ts
+function generateKey() {}
+
+class KeyObject {}
+
+type SharedKey = {};
+
+enum KeyType {
+  PublicKey,
+  PrivateKey,
+}
+
+const KEY_VERSION = "1.0.0";
+
+const KEY_MAX_LENGTH = 4294967295;
+
+const KEY_PATTERN = /^[0-9a-f]+$/;
+```
+
+Bad:
+
+```ts
+function generate_key() {}
+
+function GenerateKey() {}
+
+class keyObject {}
+
+type sharedKey = {};
+
+enum keyType {
+  publicKey,
+  privateKey,
+}
+
+const keyVersion = "1.0.0";
+
+const key_maxLength = 4294967295;
+
+const KeyPattern = /^[0-9a-f]+$/;
+```
+
+When the names are in `camelCase` or `PascalCase`, always follow the rules of
+them even when the part of API name is acronyms.
+
+Note: Web APIs use uppercase acronyms (`JSON`, `URL`, `URL.createObjectURL()`
+etc.). Deno Standard Library does not follow this convention.
 
 Good:
 

--- a/references/contributing/style_guide.md
+++ b/references/contributing/style_guide.md
@@ -397,15 +397,17 @@ class MyClass {
 
 #### Naming convention
 
-Use `camelCase` for functions. Use `PascalCase` for classes, types, interfaces,
-and enums. Use `UPPER_SNAKE_CASE` for static items, such as `string`, `number`,
-`bigint`, `boolean`, `RegExp`, arrays of static items, records of static keys
-and values, etc.
+Use `camelCase` for functions, methods, fields, and local variables. Use
+`PascalCase` for classes, types, interfaces, and enums. Use `UPPER_SNAKE_CASE`
+for static top-level items, such as `string`, `number`, `bigint`, `boolean`,
+`RegExp`, arrays of static items, records of static keys and values, etc.
 
 Good:
 
 ```ts
 function generateKey() {}
+
+let currentValue = 0;
 
 class KeyObject {}
 
@@ -428,6 +430,8 @@ Bad:
 ```ts
 function generate_key() {}
 
+let current_value = 0;
+
 function GenerateKey() {}
 
 class keyObject {}
@@ -439,7 +443,7 @@ enum keyType {
   privateKey,
 }
 
-const keyVersion = "1.0.0";
+const key_version = "1.0.0";
 
 const key_maxLength = 4294967295;
 
@@ -447,7 +451,7 @@ const KeyPattern = /^[0-9a-f]+$/;
 ```
 
 When the names are in `camelCase` or `PascalCase`, always follow the rules of
-them even when the part of API name is acronyms.
+them even when the parts of them are acronyms.
 
 Note: Web APIs use uppercase acronyms (`JSON`, `URL`, `URL.createObjectURL()`
 etc.). Deno Standard Library does not follow this convention.


### PR DESCRIPTION
This PR updates the naming convention of Deno Standard Library.

We don't mention the usage of UPPER_SNAKE_CASE in the style guide, but UPPER_SNAKE_CASE have been used in many places. That caused the discussion https://github.com/denoland/deno_std/issues/3331.

This change adds the description about the usage of UPPER_SNAKE_CASE in deno_std, and resolves the conflict between the style guide and the existing code.

closes https://github.com/denoland/deno_std/issues/3331