### PR TITLE
docs: fix typo in `transferFunds`

### DIFF
--- a/runtime/kv/transactions.md
+++ b/runtime/kv/transactions.md
@@ -77,8 +77,8 @@ async function transferFunds(sender: string, receiver: string, amount: number) {
     // to commit due to a check failure (i.e. the versionstamp for a key has
     // changed)
     res = await kv.atomic()
-      .check(senderKey) // Ensure the sender's balance hasn't changed.
-      .check(receiverKey) // Ensure the receiver's balance hasn't changed.
+      .check(senderRes) // Ensure the sender's balance hasn't changed.
+      .check(receiverRes) // Ensure the receiver's balance hasn't changed.
       .set(senderKey, newSenderBalance) // Update the sender's balance.
       .set(receiverKey, newReceiverBalance) // Update the receiver's balance.
       .commit();


### PR DESCRIPTION
Small typo in the `transferFunds` function in [runtime/kv/transactions](https://deno.com/manual@v1.33.0/runtime/kv/transactions).

Btw, the error seems a bit cryptic

```
error: Uncaught TypeError: Error parsing args at position 2: serde_v8 error: invalid type, expected: array
      .commit();
       ^
    at Object.opAsync (ext:core/01_core.js:256:30)
    at AtomicOperation.commit (ext:deno_kv/01_db.ts:196:41)
    at transferFunds (file:///path/to/file.ts:99:9)
    at async file:///path/to/file.ts:9:9
```