### PR TITLE
Replace comma delimiter with a semicolon

### DIFF
--- a/basics/modules/private.md
+++ b/basics/modules/private.md
@@ -34,7 +34,7 @@ DENO_AUTH_TOKENS=username:password@deno.land
 And multiple tokens would look like this:
 
 ```sh
-DENO_AUTH_TOKENS=a1b2c3d4e5f6@deno.land;f1e2d3c4b5a6@example.com:8080,username:password@deno.land
+DENO_AUTH_TOKENS=a1b2c3d4e5f6@deno.land;f1e2d3c4b5a6@example.com:8080;username:password@deno.land
 ```
 
 When Deno goes to fetch a remote module, where the hostname matches the hostname


### PR DESCRIPTION
On the `Private Modules and Repositories` page, the example for specifying multiple authentication tokens has one semicolon delimiter and one comma delimiter.

This PR simply replaces the comma with a semicolon.