### PR TITLE
Fix typo in deleteUser function on Secondary Indexes page

### DIFF
--- a/runtime/kv/secondary_indexes.md
+++ b/runtime/kv/secondary_indexes.md
@@ -101,7 +101,7 @@ To implement a unique secondary index for this example, follow these steps:
        res = await kv.atomic()
          .check(getRes)
          .delete(["users", id])
-         .delete(["users_by_email", res.value.email])
+         .delete(["users_by_email", getRes.value.email])
          .commit();
      }
    }


### PR DESCRIPTION
Closes #650

The current code block references the 'res' variable instead of the correct variable 'getRes' when deleting a user by email.