### PR TITLE
Make installation command for windows more compatible

### DIFF
--- a/getting_started/installation.md
+++ b/getting_started/installation.md
@@ -20,7 +20,7 @@ curl -fsSL https://deno.land/x/install/install.sh | sh
 Using PowerShell (Windows):
 
 ```shell
-irm https://deno.land/install.ps1 | iex
+iwr https://deno.land/install.ps1 | iex
 ```
 
 Using [Scoop](https://scoop.sh/) (Windows):


### PR DESCRIPTION
irm -> iwr
typo fixed

fixes #654

EDIT: this is a problem in older versions of PowerShell, but versions as recent as 5.1 seem to not have the alias.