### PR TITLE
Remove unnecessary spacing in `deno-dom` doc

### DIFF
--- a/advanced/jsx_dom/deno_dom.md
+++ b/advanced/jsx_dom/deno_dom.md
@@ -1,7 +1,6 @@
 # Using deno-dom with Deno
 
 [deno-dom](https://deno.land/x/deno_dom) is an implementation of DOM and HTML
-
 parser in Deno. It is implemented in Rust (via Wasm) and TypeScript. There is
 also a "native" implementation, leveraging the FFI interface.
 


### PR DESCRIPTION
Super tiny change. Nothing else to add here.