### PR TITLE
fix: Add 'semiColons' to 'fmt' example

### DIFF
--- a/getting_started/configuration_file.md
+++ b/getting_started/configuration_file.md
@@ -89,6 +89,7 @@ Configuration for [`deno fmt`](../tools/formatter.md)
     "useTabs": true,
     "lineWidth": 80,
     "indentWidth": 4,
+    "semiColons": true,
     "singleQuote": true,
     "proseWrap": "preserve",
     "include": ["src/"],


### PR DESCRIPTION
The "semiColons" option was the only one missing from this list, so it was a little unclear if that option existed. In `manual/tools/formatter.md` we have the cli option `--no-semicolons`, while `deno/cli/tools/fmt.rs` accepts a "semiColons" option. The only place we specify that the "semiColons" option exists for the config file is in the full example below, but it's easy to miss. Since it's the only fmt option missing in this section, I thought it would be fine if we included it here too.