### PR TITLE
Update manual to indicate that import mappings should be in deno.json

### DIFF
--- a/basics/import_maps.md
+++ b/basics/import_maps.md
@@ -40,7 +40,7 @@ written something similar in our `deno.json` configuration file:
 
 ## Example - Using deno_std's fmt module via `fmt/`
 
-**import_map.json**
+**deno.json**
 
 ```json
 {
@@ -62,7 +62,7 @@ console.log(red("hello world"));
 
 To use your project root for absolute imports:
 
-**import_map.json**
+**deno.json**
 
 ```jsonc
 {


### PR DESCRIPTION
This section of the manual seems to indicate that import mappings should be in a file called `import_map.json` and not `deno.json`, but the latter is what actually works in the runtime (without additional work). This updates those headings.