### PR TITLE
Add Workers to the "Unavailable in executables" section

### DIFF
--- a/tools/compiler.md
+++ b/tools/compiler.md
@@ -38,3 +38,4 @@ target.
 ## Unavailable in executables
 
 - [Web Storage API](../runtime/web_storage_api.md)
+- [Web Worker API](../runtime/workers.md)


### PR DESCRIPTION
Based on [the Workers page of the manual](https://deno.com/manual@v1.34.1/runtime/workers):

> Workers can be used to run code on multiple threads. Each instance of Worker is run on a separate thread, dedicated only to that worker.
>
> Currently Deno supports only module type workers; thus it’s essential to pass the type: "module" option when creating a new worker.
>
> **Workers currently do not work in compiled executables.**

(emphasis mine)

If this is no longer the case, the Worker page should be fixed instead.