### PR TITLE
docs: update `fmt` section in config file manual

### DIFF
--- a/getting_started/configuration_file.md
+++ b/getting_started/configuration_file.md
@@ -137,14 +137,17 @@ See also
     }
   },
   "fmt": {
-    "useTabs": true,
-    "lineWidth": 80,
-    "indentWidth": 4,
-    "semiColons": false,
-    "singleQuote": true,
-    "proseWrap": "preserve",
-    "include": ["src/"],
-    "exclude": ["src/testdata/", "data/fixtures/**/*.ts"]
+    "options": {
+      "lineWidth": 80,
+      "indentWidth": 4,
+      "semiColons": false,
+      "singleQuote": true,
+      "proseWrap": "preserve"
+    },
+    "files": {
+      "exclude": ["src/"],
+      "include": ["src/testdata/", "data/fixtures/**/*.ts"]
+    }
   },
   "lock": false,
   "nodeModulesDir": true,


### PR DESCRIPTION
I refactored the config file for compatibility with the new Deno version. The changes include replacing the "fmt" section with the following structure: 

```
"fmt": {
    "options": {
      "lineWidth": 80,
      "indentWidth": 4,
      "semiColons": false,
      "singleQuote": true,
      "proseWrap": "preserve"
    },
    "files": {
      "exclude": ["src/"],
      "include": ["src/testdata/", "data/fixtures/**/*.ts"]
    }
},
``` 
instead of
```
"fmt": {
    "useTabs": true,
    "lineWidth": 80,
    "indentWidth": 4,
    "semiColons": false,
    "singleQuote": true,
    "proseWrap": "preserve",
    "include": ["src/"],
    "exclude": ["src/testdata/", "data/fixtures/**/*.ts"]
},
```