### PR TITLE
Add missing apostrophes and refactor a couple of sentences

### DIFF
--- a/getting_started/setup_your_environment.md
+++ b/getting_started/setup_your_environment.md
@@ -371,10 +371,10 @@ There are several environment variables which can impact the behavior of Deno:
 - `DENO_TLS_CA_STORE` - a list of certificate stores which will be used when
   establishing TLS connections. The available stores are `mozilla` and `system`.
   You can specify one, both or none. Certificate chains attempt to resolve in
-  the same order in which you specify them. The
-  default value is `mozilla`. The `mozilla` store will use the bundled Mozilla
-  certs provided by [`webpki-roots`](https://crates.io/crates/webpki-roots). The
-  `system` store will use your platform's
+  the same order in which you specify them. The default value is `mozilla`. The
+  `mozilla` store will use the bundled Mozilla certs provided by
+  [`webpki-roots`](https://crates.io/crates/webpki-roots). The `system` store
+  will use your platform's
   [native certificate store](https://crates.io/crates/rustls-native-certs). The
   exact set of Mozilla certs will depend on the version of Deno you are using.
   If you specify no certificate stores, then no trust will be given to any TLS
@@ -400,11 +400,11 @@ There are several environment variables which can impact the behavior of Deno:
   [Proxies](../basics/modules/proxies.md) section for more information.
 - `HTTPS_PROXY` - The proxy address to use for HTTPS requests. See the
   [Proxies](../basics/modules/proxies.md) section for more information.
-- `NO_COLOR` - If set, this will prevent the Deno CLI from sending ANSI color codes
-  when writing to stdout and stderr. See the website <https://no-color.org/> for
-  more information on this _de facto_ standard. The value of this flag can be
-  accessed at runtime without permission to read the environment variables by
-  checking the value of `Deno.noColor`.
+- `NO_COLOR` - If set, this will prevent the Deno CLI from sending ANSI color
+  codes when writing to stdout and stderr. See the website
+  <https://no-color.org/> for more information on this _de facto_ standard. The
+  value of this flag can be accessed at runtime without permission to read the
+  environment variables by checking the value of `Deno.noColor`.
 - `NO_PROXY` - Indicates hosts which should bypass the proxy set in the other
   environment variables. See the [Proxies](../basics/modules/proxies.md) section
   for more information.

--- a/getting_started/setup_your_environment.md
+++ b/getting_started/setup_your_environment.md
@@ -370,11 +370,11 @@ There are several environment variables which can impact the behavior of Deno:
   more details.
 - `DENO_TLS_CA_STORE` - a list of certificate stores which will be used when
   establishing TLS connections. The available stores are `mozilla` and `system`.
-  You can specify one, both or none. The order you specify the store determines
-  the order in which certificate chains will be attempted to resolved. The
+  You can specify one, both or none. Certificate chains attempt to resolve in
+  the same order in which you specify them. The
   default value is `mozilla`. The `mozilla` store will use the bundled Mozilla
   certs provided by [`webpki-roots`](https://crates.io/crates/webpki-roots). The
-  `system` store will use your platforms
+  `system` store will use your platform's
   [native certificate store](https://crates.io/crates/rustls-native-certs). The
   exact set of Mozilla certs will depend on the version of Deno you are using.
   If you specify no certificate stores, then no trust will be given to any TLS
@@ -386,7 +386,7 @@ There are several environment variables which can impact the behavior of Deno:
 - `DENO_DIR` - this will set the directory where cached information from the CLI
   is stored. This includes items like cached remote modules, cached transpiled
   modules, language server cache information and persisted data from local
-  storage. This defaults to the operating systems default cache location and
+  storage. This defaults to the operating system's default cache location and
   then under the `deno` path.
 - `DENO_INSTALL_ROOT` - When using `deno install` where the installed scripts
   are stored. This defaults to `$HOME/.deno/bin`.
@@ -400,7 +400,7 @@ There are several environment variables which can impact the behavior of Deno:
   [Proxies](../basics/modules/proxies.md) section for more information.
 - `HTTPS_PROXY` - The proxy address to use for HTTPS requests. See the
   [Proxies](../basics/modules/proxies.md) section for more information.
-- `NO_COLOR` - If set, this will cause the Deno CLI to not send ANSI color codes
+- `NO_COLOR` - If set, this will prevent the Deno CLI from sending ANSI color codes
   when writing to stdout and stderr. See the website <https://no-color.org/> for
   more information on this _de facto_ standard. The value of this flag can be
   accessed at runtime without permission to read the environment variables by


### PR DESCRIPTION
As I was reading the docs, I noticed a couple of missing apostrophes in this file; this corrects those.

While I was there, I also noticed a couple of sentences in the `Environment variables` section with potentially confusing wording (using double negatives, or roundabout passive voice), and decided we may as well tidy those up while we're here. (That's if the change is agreed upon as an improvement, of course.) :)