### PR TITLE
Internal style guide - Remove section on not using the word “library”

### DIFF
--- a/references/contributing/style_guide.md
+++ b/references/contributing/style_guide.md
@@ -57,12 +57,6 @@ The TypeScript portion of the code base is the standard library `std`.
 
 ### Use TypeScript instead of JavaScript.
 
-### Use the term "module" instead of "library" or "package".
-
-For clarity and consistency, avoid the terms "library" and "package". Instead
-use "module" to refer to a single JS or TS file and also to refer to a directory
-of TS/JS code.
-
 ### Do not use the filename `index.ts`/`index.js`.
 
 Deno does not treat "index.js" or "index.ts" in a special way. By using these


### PR DESCRIPTION
It’s useful to have separate words for these concepts. I think this might have been intended to only apply to the folders within deno_std.