### PR TITLE
Prevent whole filesystem read exploit in file server example

### DIFF
--- a/examples/file_server.md
+++ b/examples/file_server.md
@@ -16,7 +16,7 @@ memory.
 
 ## Example
 
-**Command:** `deno run --allow-read --allow-net file_server.ts`
+**Command:** `deno run --allow-read=. --allow-net file_server.ts`
 
 ```ts
 // Start listening on port 8080 of localhost.


### PR DESCRIPTION
[The example](https://deno.land/manual@v1.35.2/examples/file_server) suggests running the server with a global `--allow-read` permission, and the implementation simply appends the URL-decoded request pathname to '.' before reading whatever file is there.

By URL-encoding slashes as "%2F", an attacker can easily escape the current directory and ultimately read anything that the deno process can read in the whole filesystem by calling the file server (for example, "/..%2F..%2F..%2F.ssh/config" or however many times "../" is needed to backtrack to the user directory).

Thankfully, deno was designed to prevent this kind of exploit without even looking at the code. This PR just narrows `--allow-read` to the current directory to match what the code *seems to be doing*.