### PR TITLE
reflect std/testing/asserts to std/asserts move in manual

### DIFF
--- a/advanced/jsx_dom/css.md
+++ b/advanced/jsx_dom/css.md
@@ -27,7 +27,7 @@ Then we will stringify the modified CSS AST and output it to the console:
 
 ```ts, ignore
 import * as css from "https://esm.sh/css@3.0.0";
-import { assert } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+import { assert } from "https://deno.land/std@$STD_VERSION/assert/assert.ts";
 
 declare global {
   interface AbortSignal {

--- a/advanced/jsx_dom/css.md
+++ b/advanced/jsx_dom/css.md
@@ -27,7 +27,7 @@ Then we will stringify the modified CSS AST and output it to the console:
 
 ```ts, ignore
 import * as css from "https://esm.sh/css@3.0.0";
-import { assert } from "https://deno.land/std@$STD_VERSION/assert/assert.ts";
+import { assert } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 
 declare global {
   interface AbortSignal {

--- a/advanced/jsx_dom/deno_dom.md
+++ b/advanced/jsx_dom/deno_dom.md
@@ -20,7 +20,7 @@ first heading it encounters and print out the text content of that heading:
 
 ```ts
 import { DOMParser } from "https://deno.land/x/deno_dom/deno-dom-wasm.ts";
-import { assert } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+import { assert } from "https://deno.land/std@$STD_VERSION/assert/assert.ts";
 
 const document = new DOMParser().parseFromString(
   `<!DOCTYPE html>

--- a/advanced/jsx_dom/deno_dom.md
+++ b/advanced/jsx_dom/deno_dom.md
@@ -20,7 +20,7 @@ first heading it encounters and print out the text content of that heading:
 
 ```ts
 import { DOMParser } from "https://deno.land/x/deno_dom/deno-dom-wasm.ts";
-import { assert } from "https://deno.land/std@$STD_VERSION/assert/assert.ts";
+import { assert } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 
 const document = new DOMParser().parseFromString(
   `<!DOCTYPE html>

--- a/advanced/jsx_dom/jsdom.md
+++ b/advanced/jsx_dom/jsdom.md
@@ -66,7 +66,7 @@ first heading it encounters and print out the text content of that heading:
 
 ```ts, ignore
 import { JSDOM } from "jsdom";
-import { assert } from "https://deno.land/std@$STD_VERSION/assert/assert.ts";
+import { assert } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 
 const { window: { document } } = new JSDOM(
   `<!DOCTYPE html>

--- a/advanced/jsx_dom/jsdom.md
+++ b/advanced/jsx_dom/jsdom.md
@@ -66,7 +66,7 @@ first heading it encounters and print out the text content of that heading:
 
 ```ts, ignore
 import { JSDOM } from "jsdom";
-import { assert } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+import { assert } from "https://deno.land/std@$STD_VERSION/assert/assert.ts";
 
 const { window: { document } } = new JSDOM(
   `<!DOCTYPE html>

--- a/advanced/jsx_dom/linkedom.md
+++ b/advanced/jsx_dom/linkedom.md
@@ -29,7 +29,7 @@ first heading it encounters and print out the text content of that heading:
 
 ```ts
 import { DOMParser } from "https://esm.sh/linkedom";
-import { assert } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+import { assert } from "https://deno.land/std@$STD_VERSION/assert/assert.ts";
 
 const document = new DOMParser().parseFromString(
   `<!DOCTYPE html>

--- a/advanced/jsx_dom/linkedom.md
+++ b/advanced/jsx_dom/linkedom.md
@@ -29,7 +29,7 @@ first heading it encounters and print out the text content of that heading:
 
 ```ts
 import { DOMParser } from "https://esm.sh/linkedom";
-import { assert } from "https://deno.land/std@$STD_VERSION/assert/assert.ts";
+import { assert } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 
 const document = new DOMParser().parseFromString(
   `<!DOCTYPE html>

--- a/basics/modules.md
+++ b/basics/modules.md
@@ -136,7 +136,7 @@ The solution is to import and re-export your external libraries in a central
 `deps.ts` file (which serves the same purpose as Node's `package.json` file).
 For example, let's say you were using the above assertion library across a large
 project. Rather than importing
-`"https://deno.land/std@$STD_VERSION/testing/asserts.ts"` everywhere, you could
+`"https://deno.land/std@$STD_VERSION/assert/mod.ts"` everywhere, you could
 create a `deps.ts` file that exports the third-party code:
 
 **deps.ts**
@@ -146,7 +146,7 @@ export {
   assert,
   assertEquals,
   assertStringIncludes,
-} from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+} from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 ```
 
 And throughout the same project, you can import from the `deps.ts` and avoid

--- a/basics/testing.md
+++ b/basics/testing.md
@@ -10,7 +10,7 @@ Firstly, let's create a file `url_test.ts` and register a test case using
 
 ```ts
 // url_test.ts
-import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
 
 Deno.test("url test", () => {
   const url = new URL("./foo.js", "https://deno.land/");
@@ -36,7 +36,7 @@ switching between the forms (eg. when you need to quickly focus a single test
 for debugging, using `only: true` option):
 
 ```ts
-import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
 
 // Compact form: name and function
 Deno.test("hello world #1", () => {
@@ -107,7 +107,7 @@ The test steps API provides a way to report distinct steps within a test and do
 setup and teardown code within that test.
 
 ```ts
-import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
 import { Client } from "https://deno.land/x/postgres@v0.15.0/mod.ts";
 
 interface User {
@@ -470,7 +470,7 @@ around `bar` and call `foo(spy)` in the testing code:
 
 ```js, ignore
 import sinon from "https://cdn.skypack.dev/sinon";
-import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
 import { bar, foo } from "./my_file.js";
 
 Deno.test("calls bar during execution of foo", () => {
@@ -510,7 +510,7 @@ And then `import` in a test file:
 
 ```js, ignore
 import sinon from "https://cdn.skypack.dev/sinon";
-import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
 import { foo, funcs } from "./my_file.js";
 
 Deno.test("calls bar during execution of foo", () => {

--- a/basics/testing.md
+++ b/basics/testing.md
@@ -10,7 +10,7 @@ Firstly, let's create a file `url_test.ts` and register a test case using
 
 ```ts
 // url_test.ts
-import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 
 Deno.test("url test", () => {
   const url = new URL("./foo.js", "https://deno.land/");
@@ -36,7 +36,7 @@ switching between the forms (eg. when you need to quickly focus a single test
 for debugging, using `only: true` option):
 
 ```ts
-import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 
 // Compact form: name and function
 Deno.test("hello world #1", () => {
@@ -107,7 +107,7 @@ The test steps API provides a way to report distinct steps within a test and do
 setup and teardown code within that test.
 
 ```ts
-import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 import { Client } from "https://deno.land/x/postgres@v0.15.0/mod.ts";
 
 interface User {
@@ -470,7 +470,7 @@ around `bar` and call `foo(spy)` in the testing code:
 
 ```js, ignore
 import sinon from "https://cdn.skypack.dev/sinon";
-import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 import { bar, foo } from "./my_file.js";
 
 Deno.test("calls bar during execution of foo", () => {
@@ -510,7 +510,7 @@ And then `import` in a test file:
 
 ```js, ignore
 import sinon from "https://cdn.skypack.dev/sinon";
-import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 import { foo, funcs } from "./my_file.js";
 
 Deno.test("calls bar during execution of foo", () => {

--- a/basics/testing/assertions.md
+++ b/basics/testing/assertions.md
@@ -5,7 +5,7 @@ To help developers write tests the Deno standard library comes with a built-in
 be imported from `https://deno.land/std@$STD_VERSION/assert/mod.ts`.
 
 ```js
-import { assert } from "https://deno.land/std@$STD_VERSION/assert/assert.ts";
+import { assert } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 
 Deno.test("Hello Test", () => {
   assert("Hello");

--- a/basics/testing/assertions.md
+++ b/basics/testing/assertions.md
@@ -1,11 +1,11 @@
 # Assertions
 
 To help developers write tests the Deno standard library comes with a built-in
-[assertions module](https://deno.land/std@$STD_VERSION/testing/asserts.ts) which
-can be imported from `https://deno.land/std@$STD_VERSION/testing/asserts.ts`.
+[assertions module](https://deno.land/std@$STD_VERSION/assert/mod.ts) which can
+be imported from `https://deno.land/std@$STD_VERSION/assert/mod.ts`.
 
 ```js
-import { assert } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+import { assert } from "https://deno.land/std@$STD_VERSION/assert/assert.ts";
 
 Deno.test("Hello Test", () => {
   assert("Hello");
@@ -128,7 +128,7 @@ That's especially true when working with decimal numbers, where
 import {
   assertStrictEquals,
   assertThrows,
-} from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+} from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 
 Deno.test("Test Assert Strict Equals with float numbers", () => {
   assertStrictEquals(0.25 + 0.25, 0.25);
@@ -145,7 +145,7 @@ it is possible to change it by passing a third optional parameter.
 import {
   assertAlmostEquals,
   assertThrows,
-} from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+} from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 
 Deno.test("Test Assert Almost Equals", () => {
   assertAlmostEquals(0.1 + 0.2, 0.3);
@@ -161,7 +161,7 @@ To check if an object is an instance of a specific constructor, you can use
 the passed in variable has a specific type:
 
 ```ts
-import { assertInstanceOf } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+import { assertInstanceOf } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 
 Deno.test("Test Assert Instance Type", () => {
   const variable = new Date() as unknown;
@@ -305,13 +305,13 @@ Deno.test("Test Assert Equal Fail Custom Message", () => {
 ## Custom Tests
 
 While Deno comes with powerful
-[assertions modules](https://deno.land/std@$STD_VERSION/testing/asserts.ts) but
-there is always something specific to the project you can add. Creating
+[assertions modules](https://deno.land/std@$STD_VERSION/assert/mod.ts) but there
+is always something specific to the project you can add. Creating
 `custom assertion function` can improve readability and reduce the amount of
 code.
 
 ```ts
-import { AssertionError } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+import { AssertionError } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 
 function assertPowerOf(actual: number, expected: number, msg?: string): void {
   let received = actual;

--- a/basics/testing/behavior_driven_development.md
+++ b/basics/testing/behavior_driven_development.md
@@ -90,7 +90,7 @@ import {
   assertEquals,
   assertStrictEquals,
   assertThrows,
-} from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+} from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 import { User } from "https://deno.land/std@$STD_VERSION/testing/bdd_examples/user.ts";
 
 Deno.test("User.users initially empty", () => {
@@ -135,7 +135,7 @@ import {
   assertEquals,
   assertStrictEquals,
   assertThrows,
-} from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+} from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 import {
   afterEach,
   beforeEach,
@@ -197,7 +197,7 @@ import {
   assertEquals,
   assertStrictEquals,
   assertThrows,
-} from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+} from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 import {
   describe,
   it,
@@ -257,7 +257,7 @@ import {
   assertEquals,
   assertStrictEquals,
   assertThrows,
-} from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+} from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 import {
   describe,
   it,

--- a/basics/testing/mocking.md
+++ b/basics/testing/mocking.md
@@ -39,7 +39,7 @@ import {
   assertSpyCalls,
   spy,
 } from "https://deno.land/std@$STD_VERSION/testing/mock.ts";
-import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
 import {
   multiply,
   square,
@@ -92,7 +92,7 @@ import {
   assertSpyCalls,
   spy,
 } from "https://deno.land/std@$STD_VERSION/testing/mock.ts";
-import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
 import {
   _internals,
   square,
@@ -176,7 +176,7 @@ import {
   returnsNext,
   stub,
 } from "https://deno.land/std@$STD_VERSION/testing/mock.ts";
-import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
 import {
   _internals,
   randomMultiple,

--- a/basics/testing/mocking.md
+++ b/basics/testing/mocking.md
@@ -39,7 +39,7 @@ import {
   assertSpyCalls,
   spy,
 } from "https://deno.land/std@$STD_VERSION/testing/mock.ts";
-import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 import {
   multiply,
   square,
@@ -92,7 +92,7 @@ import {
   assertSpyCalls,
   spy,
 } from "https://deno.land/std@$STD_VERSION/testing/mock.ts";
-import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 import {
   _internals,
   square,
@@ -176,7 +176,7 @@ import {
   returnsNext,
   stub,
 } from "https://deno.land/std@$STD_VERSION/testing/mock.ts";
-import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 import {
   _internals,
   randomMultiple,

--- a/getting_started/configuration_file.md
+++ b/getting_started/configuration_file.md
@@ -37,7 +37,7 @@ import maps.
 Then your script can use the bare specifier `std`:
 
 ```js, ignore
-import { assertEquals } from "std/testing/assert.ts";
+import { assertEquals } from "std/assert/mod.ts";
 
 assertEquals(1, 2);
 ```

--- a/references/contributing/style_guide.md
+++ b/references/contributing/style_guide.md
@@ -313,7 +313,7 @@ test myTestFunction ... ok
 Example of test:
 
 ```ts, ignore
-import { assertEquals } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
 import { foo } from "./mod.ts";
 
 Deno.test("myTestFunction", function () {

--- a/references/contributing/style_guide.md
+++ b/references/contributing/style_guide.md
@@ -313,7 +313,7 @@ test myTestFunction ... ok
 Example of test:
 
 ```ts, ignore
-import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/assert_equals.ts";
+import { assertEquals } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 import { foo } from "./mod.ts";
 
 Deno.test("myTestFunction", function () {

--- a/references/vscode_deno.md
+++ b/references/vscode_deno.md
@@ -189,7 +189,7 @@ default which provides the ability to run a test from within the editor.
 When you have a block of code that provides a test, like:
 
 ```ts
-import { assert } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts";
+import { assert } from "https://deno.land/std@$STD_VERSION/assert/assert.ts";
 
 Deno.test({
   name: "a test case",

--- a/references/vscode_deno.md
+++ b/references/vscode_deno.md
@@ -189,7 +189,7 @@ default which provides the ability to run a test from within the editor.
 When you have a block of code that provides a test, like:
 
 ```ts
-import { assert } from "https://deno.land/std@$STD_VERSION/assert/assert.ts";
+import { assert } from "https://deno.land/std@$STD_VERSION/assert/mod.ts";
 
 Deno.test({
   name: "a test case",

--- a/tools/repl.md
+++ b/tools/repl.md
@@ -50,14 +50,14 @@ into the REPL. This is useful for importing some code you commonly use in the
 REPL, or modifying the runtime in some way:
 
 ```
-$ deno repl --allow-net --eval 'import { assert } from "https://deno.land/std@0.178.0/testing/asserts.ts"'
-Deno 1.31.0
-exit using ctrl+d or close()
+$ deno repl --allow-net --eval 'import { assert } from "https://deno.land/std@$STD_VERSION/assert/mod.ts"'
+Deno 1.36.0
+exit using ctrl+d, ctrl+c, or close()
 > assert(true)
 undefined
 > assert(false)
 Uncaught AssertionError
-    at assert (https://deno.land/std@0.178.0/testing/asserts.ts:141:11)
+    at assert (https://deno.land/std@0.197.0/assert/assert.ts:7:11)
     at <anonymous>:2:1
 ```
 

--- a/tools/repl.md
+++ b/tools/repl.md
@@ -50,7 +50,7 @@ into the REPL. This is useful for importing some code you commonly use in the
 REPL, or modifying the runtime in some way:
 
 ```
-$ deno repl --allow-net --eval 'import { assert } from "https://deno.land/std@$STD_VERSION/testing/asserts.ts"'
+$ deno repl --allow-net --eval 'import { assert } from "https://deno.land/std@0.178.0/testing/asserts.ts"'
 Deno 1.31.0
 exit using ctrl+d or close()
 > assert(true)


### PR DESCRIPTION
Users copy-pasting testing code from the docs currently encounter a deprecation notice because of the moved assertions.

This fixes imports changed by https://github.com/denoland/deno_std/pull/3445.

Also closes #558.

Fixes std version in `tools/repl.md` to be consistent with displayed output.