### PR TITLE
fix: update hello world program url

### DIFF
--- a/getting_started/first_steps.md
+++ b/getting_started/first_steps.md
@@ -32,8 +32,8 @@ deno run first_steps.ts
 ```
 
 Deno also has the ability to execute scripts from URLs. Deno
-[hosts a library](https://examples.deno.land/) of example code,
-one of which is a `Hello World` program. To run that hosted code, do:
+[hosts a library](https://examples.deno.land/) of example code, one of which is
+a `Hello World` program. To run that hosted code, do:
 
 ```shell
 deno run https://examples.deno.land/hello-world.ts

--- a/getting_started/first_steps.md
+++ b/getting_started/first_steps.md
@@ -36,7 +36,7 @@ Deno also has the ability to execute scripts from URLs. Deno
 one of which is a `Hello World` program. To run that hosted code, do:
 
 ```shell
-deno run https://deno.land/std@$STD_VERSION/examples/welcome.ts
+deno run https://examples.deno.land/hello-world.ts
 ```
 
 ## Making an HTTP request

--- a/getting_started/first_steps.md
+++ b/getting_started/first_steps.md
@@ -32,7 +32,7 @@ deno run first_steps.ts
 ```
 
 Deno also has the ability to execute scripts from URLs. Deno
-[hosts a library](https://deno.land/std@$STD_VERSION/examples) of example code,
+[hosts a library](https://examples.deno.land/) of example code,
 one of which is a `Hello World` program. To run that hosted code, do:
 
 ```shell

--- a/tools/compiler.md
+++ b/tools/compiler.md
@@ -4,7 +4,7 @@
 self-contained executable.
 
 ```
-> deno compile https://deno.land/std/examples/welcome.ts
+> deno compile https://examples.deno.land/hello-world.ts
 ```
 
 If you omit the `OUT` parameter, the name of the executable file will be


### PR DESCRIPTION
We removed std/examples in https://github.com/denoland/deno_std/pull/3546, and the referenced hello world doesn't exist anymore.

This PR updates the hello world program url to https://examples.deno.land/hello-world.ts