### PR TITLE
fix: pin std/examples to v0.198.0

### DIFF
--- a/basics/permissions.md
+++ b/basics/permissions.md
@@ -100,7 +100,7 @@ This example restricts file system access by allowing read-only access to the
 attempting to read a file in the `/etc` directory:
 
 ```shell
-$ deno run --allow-read=/usr https://deno.land/std@$STD_VERSION/examples/cat.ts /etc/passwd
+$ deno run --allow-read=/usr https://deno.land/std@0.198.0/examples/cat.ts /etc/passwd
 error: Uncaught PermissionDenied: read access to "/etc/passwd", run again with the --allow-read flag
 ► $deno$/dispatch_json.ts:40:11
     at DenoError ($deno$/errors.ts:20:5)
@@ -111,15 +111,15 @@ Try it out again with the correct permissions by allowing access to `/etc`
 instead:
 
 ```shell
-deno run --allow-read=/etc https://deno.land/std@$STD_VERSION/examples/cat.ts /etc/passwd
+deno run --allow-read=/etc https://deno.land/std@0.198.0/examples/cat.ts /etc/passwd
 ```
 
 You can further restrict some sub-paths to not be accessible, using
 `--deny-read` flag:
 
 ```shell
-deno run --allow-read=/etc --deny-read=/etc/hosts https://deno.land/std@$STD_VERSION/examples/cat.ts /etc/passwd
-deno run --allow-read=/etc --deny-read=/etc/hosts https://deno.land/std@$STD_VERSION/examples/cat.ts /etc/hosts
+deno run --allow-read=/etc --deny-read=/etc/hosts https://deno.land/std@0.198.0/examples/cat.ts /etc/passwd
+deno run --allow-read=/etc --deny-read=/etc/hosts https://deno.land/std@0.198.0/examples/cat.ts /etc/hosts
 error: Uncaught PermissionDenied: read access to "/etc/hosts"...
 ```
 

--- a/examples/tcp_server.md
+++ b/examples/tcp_server.md
@@ -17,7 +17,7 @@ For security reasons, Deno does not allow programs to access the network without
 explicit permission. To allow accessing the network, use a command-line flag:
 
 ```shell
-deno run --allow-net https://deno.land/std@$STD_VERSION/examples/echo_server.ts
+deno run --allow-net https://deno.land/std@0.198.0/examples/echo_server.ts
 ```
 
 To test it, try sending data to it with `netcat` (or `telnet` on Windows):

--- a/examples/unix_cat.md
+++ b/examples/unix_cat.md
@@ -30,5 +30,5 @@ for (const filename of Deno.args) {
 To run the program:
 
 ```shell
-deno run --allow-read https://deno.land/std@$STD_VERSION/examples/cat.ts /etc/passwd
+deno run --allow-read https://deno.land/std@0.198.0/examples/cat.ts /etc/passwd
 ```

--- a/getting_started/first_steps.md
+++ b/getting_started/first_steps.md
@@ -68,8 +68,7 @@ Try it out:
 deno run first_steps.ts
 ```
 
-Or, try this script hosted at
-`https://deno.land/std@0.198.0/examples/curl.ts`:
+Or, try this script hosted at `https://deno.land/std@0.198.0/examples/curl.ts`:
 
 ```shell
 deno run https://deno.land/std@0.198.0/examples/curl.ts https://deno.com

--- a/getting_started/first_steps.md
+++ b/getting_started/first_steps.md
@@ -69,10 +69,10 @@ deno run first_steps.ts
 ```
 
 Or, try this script hosted at
-`https://deno.land/std@$STD_VERSION/examples/curl.ts`:
+`https://deno.land/std@0.198.0/examples/curl.ts`:
 
 ```shell
-deno run https://deno.land/std@$STD_VERSION/examples/curl.ts https://deno.com
+deno run https://deno.land/std@0.198.0/examples/curl.ts https://deno.com
 ```
 
 The program will display a prompt like this:
@@ -98,7 +98,7 @@ deno run --allow-net=deno.com first_steps.ts
 Or, using the curl script:
 
 ```shell
-deno run --allow-net=deno.com https://deno.land/std@$STD_VERSION/examples/curl.ts https://deno.com
+deno run --allow-net=deno.com https://deno.land/std@0.198.0/examples/curl.ts https://deno.com
 ```
 
 ## Reading a file
@@ -132,10 +132,10 @@ Try the program:
 
 ```shell
 # macOS / Linux
-deno run --allow-read https://deno.land/std@$STD_VERSION/examples/cat.ts /etc/hosts
+deno run --allow-read https://deno.land/std@0.198.0/examples/cat.ts /etc/hosts
 
 # Windows
-deno run --allow-read https://deno.land/std@$STD_VERSION/examples/cat.ts "C:\Windows\System32\Drivers\etc\hosts"
+deno run --allow-read https://deno.land/std@0.198.0/examples/cat.ts "C:\Windows\System32\Drivers\etc\hosts"
 ```
 
 ## Putting it all together in an HTTP server

--- a/tools/bundler.md
+++ b/tools/bundler.md
@@ -6,10 +6,10 @@
 Deno, which includes all dependencies of the specified input. For example:
 
 ```bash
-deno bundle https://deno.land/std@$STD_VERSION/examples/colors.ts colors.bundle.js
-Bundle https://deno.land/std@$STD_VERSION/examples/colors.ts
-Download https://deno.land/std@$STD_VERSION/examples/colors.ts
-Download https://deno.land/std@$STD_VERSION/fmt/colors.ts
+deno bundle https://deno.land/std@0.198.0/examples/colors.ts colors.bundle.js
+Bundle https://deno.land/std@0.198.0/examples/colors.ts
+Download https://deno.land/std@0.198.0/examples/colors.ts
+Download https://deno.land/std@0.198.0/fmt/colors.ts
 Emit "colors.bundle.js" (9.83KB)
 ```
 


### PR DESCRIPTION
We removed `std/examples` in https://github.com/denoland/deno_std/pull/3546 (because there are dedicated places for examples such https://examples.deno.land/ and https://github.com/denoland/examples ), and `std/examples` doesn't exist for the latest version of std anymore.

This PR pins the references to `std/examples` to the last existing version.