### PR TITLE
Update http_server.md to use Deno.serve

### DIFF
--- a/examples/http_server.md
+++ b/examples/http_server.md
@@ -9,7 +9,7 @@
 With just a few lines of code you can run your own HTTP web server with control
 over the response status, request headers and more.
 
-## Sample web server
+## Using the `Deno.listen`
 
 In this example, the user-agent of the client is returned to the client:
 
@@ -57,19 +57,11 @@ deno run --allow-net webserver.ts
 
 Then navigate to `http://localhost:8080/` in a browser.
 
-### Using the `std/http` library
-
-> ℹ️ Since
-> [the stabilization of _native_ HTTP bindings in
-`^1.13.x`](https://deno.com/blog/v1.13#stabilize-native-http-server-api),
-> std/http now supports a _native_ HTTP server from ^0.107.0. The legacy server
-> module was removed in 0.117.0.
+### Using the `Deno.serve`
 
 **webserver.ts**:
 
 ```ts
-import { serve } from "https://deno.land/std@$STD_VERSION/http/server.ts";
-
 const port = 8080;
 
 const handler = (request: Request): Response => {
@@ -81,7 +73,7 @@ const handler = (request: Request): Response => {
 };
 
 console.log(`HTTP webserver running. Access it at: http://localhost:8080/`);
-await serve(handler, { port });
+Deno.serve({ port }, handler);
 ```
 
 Then run this with:


### PR DESCRIPTION
Addresses https://github.com/denoland/manual/issues/700 by removing deprecated example with Deno.serve

I have completely removed existing `std/http` example as it is [deprecated](https://deno.land/std@0.201.0/http/mod.ts?s=serve).